### PR TITLE
Kicks

### DIFF
--- a/Moblin/Platforms/Kick/KickApi.swift
+++ b/Moblin/Platforms/Kick/KickApi.swift
@@ -21,6 +21,7 @@ struct KickLivestream: Codable {
 
 struct KickChatroom: Codable {
     let id: Int
+    let channel_id: Int
 }
 
 struct KickChannel: Codable {

--- a/Moblin/Various/Model/ModelKick.swift
+++ b/Moblin/Various/Model/ModelKick.swift
@@ -44,6 +44,7 @@ extension Model {
                 delegate: self,
                 channelName: stream.kickChannelName,
                 channelId: channelId,
+                chatroomChannelId: stream.kickChatroomChannelId,
                 settings: stream.chat
             )
             kickPusher!.start()
@@ -75,6 +76,7 @@ extension Model {
                 if let channelInfo {
                     self.stream.kickChannelId = String(channelInfo.chatroom.id)
                     self.stream.kickSlug = channelInfo.slug
+                    self.stream.kickChatroomChannelId = String(channelInfo.chatroom.channel_id)
                 }
                 self.kickChannelNameUpdated()
             }
@@ -273,6 +275,23 @@ extension Model: KickPusherDelegate {
                 title: title,
                 color: .red,
                 image: "nosign"
+            )
+        }
+    }
+
+    func kickPusherKicksGifted(event: KicksGiftedEvent) {
+        DispatchQueue.main.async {
+            let user = event.sender.username
+            let amount = countFormatter.format(event.gift.amount)
+            let text = "sent \(event.gift.name) 💎 \(amount)"
+            let message = event.message.isEmpty ? text : "\(text) \(event.message)"
+            self.makeToast(title: "\(user) \(message)")
+            self.appendKickChatAlertMessage(
+                user: user,
+                text: message,
+                title: String(localized: "Kicks"),
+                color: .green,
+                image: "suit.diamond"
             )
         }
     }

--- a/Moblin/Various/Settings.swift
+++ b/Moblin/Various/Settings.swift
@@ -724,6 +724,7 @@ class SettingsStream: Codable, Identifiable, Equatable, ObservableObject, Named 
     @Published var twitchSendMessagesTo: Bool = true
     var kickChannelName: String = ""
     @Published var kickChannelId: String?
+    @Published var kickChatroomChannelId: String?
     @Published var kickSlug: String?
     var kickAccessToken: String = ""
     @Published var kickLoggedIn: Bool = false
@@ -801,6 +802,7 @@ class SettingsStream: Codable, Identifiable, Equatable, ObservableObject, Named 
              twitchSendMessagesTo,
              kickChannelName,
              kickChannelId,
+             kickChatroomChannelId,
              kickSlug,
              kickAccessToken,
              kickLoggedIn,
@@ -874,6 +876,7 @@ class SettingsStream: Codable, Identifiable, Equatable, ObservableObject, Named 
         try container.encode(.twitchSendMessagesTo, twitchSendMessagesTo)
         try container.encode(.kickChannelName, kickChannelName)
         try container.encode(.kickChannelId, kickChannelId)
+        try container.encode(.kickChatroomChannelId, kickChatroomChannelId)
         try container.encode(.kickSlug, kickSlug)
         try container.encode(.kickAccessToken, kickAccessToken)
         try container.encode(.kickLoggedIn, kickLoggedIn)
@@ -945,6 +948,7 @@ class SettingsStream: Codable, Identifiable, Equatable, ObservableObject, Named 
         twitchSendMessagesTo = container.decode(.twitchSendMessagesTo, Bool.self, true)
         kickChannelName = container.decode(.kickChannelName, String.self, "")
         kickChannelId = container.decode(.kickChannelId, String?.self, nil)
+        kickChatroomChannelId = container.decode(.kickChatroomChannelId, String?.self, nil)
         kickSlug = container.decode(.kickSlug, String?.self, nil)
         kickAccessToken = container.decode(.kickAccessToken, String.self, "")
         kickLoggedIn = container.decode(.kickLoggedIn, Bool.self, false)
@@ -1011,6 +1015,7 @@ class SettingsStream: Codable, Identifiable, Equatable, ObservableObject, Named 
         new.twitchSendMessagesTo = twitchSendMessagesTo
         new.kickChannelName = kickChannelName
         new.kickChannelId = kickChannelId
+        new.kickChatroomChannelId = kickChatroomChannelId
         new.kickSlug = kickSlug
         new.kickAccessToken = kickAccessToken
         new.kickLoggedIn = kickLoggedIn

--- a/Moblin/View/Settings/Streams/Stream/Kick/StreamKickSettingsView.swift
+++ b/Moblin/View/Settings/Streams/Stream/Kick/StreamKickSettingsView.swift
@@ -139,6 +139,7 @@ struct StreamKickSettingsView: View {
                 if let channelInfo {
                     self.stream.kickChannelId = String(channelInfo.chatroom.id)
                     self.stream.kickSlug = channelInfo.slug
+                    self.stream.kickChatroomChannelId = String(channelInfo.chatroom.channel_id)
                 } else {
                     fetchChannelInfoFailed = true
                 }


### PR DESCRIPTION
Added support for Kick kicks (equivalent to Twitch bits):

  1. Parse kicks events - Added structs to decode KicksGifted JSON from Pusher
  2. Subscribe to kicks channel - Added chatroom.channel_id field and subscription to channel_{id}
  3. Display kicks - Show toast notification and chat message with "sent [gift] 💎 [amount]" format

  Result: Kick kicks now work exactly like Twitch bits - same green
  highlight, same chat integration, same toast notifications.