### PR TITLE
SRTLA: choose connection used to register the group by probing RTT

### DIFF
--- a/Moblin/Media/Srtla/Client/RemoteConnection.swift
+++ b/Moblin/Media/Srtla/Client/RemoteConnection.swift
@@ -26,6 +26,7 @@ private let windowIncrement = 30
 
 protocol RemoteConnectionDelegate: AnyObject {
     func remoteConnectionOnSocketConnected(connection: RemoteConnection)
+    func remoteConnectionOnRegNgp(connection: RemoteConnection)
     func remoteConnectionOnReg2(groupId: Data)
     func remoteConnectionOnRegistered()
     func remoteConnectionPacketHandler(packet: Data)
@@ -193,11 +194,17 @@ class RemoteConnection {
         }
     }
 
+    func probe() {
+        groupId = Data.random(length: 256)
+        sendSrtlaReg2()
+    }
+
     func register(groupId: Data) {
         self.groupId = groupId
         hasFullGroupId = true
         if state == .shouldSendRegisterRequest {
             sendSrtlaReg2()
+            state = .waitForRegisterResponse
         }
     }
 
@@ -311,6 +318,7 @@ class RemoteConnection {
                 connectTimer.stop()
             } else if self.state == .shouldSendRegisterRequest || hasFullGroupId {
                 sendSrtlaReg2()
+                self.state = .waitForRegisterResponse
             } else {
                 self.state = .shouldSendRegisterRequest
             }
@@ -395,7 +403,6 @@ class RemoteConnection {
         var packet = createSrtlaPacket(type: .reg2, length: srtControlTypeSize + groupId.count)
         packet[srtControlTypeSize...] = groupId
         sendPacket(packet: packet)
-        state = .waitForRegisterResponse
     }
 
     private func sendSrtlaKeepalive() {
@@ -478,6 +485,7 @@ class RemoteConnection {
 
     private func handleSrtlaRegNgp() {
         logger.debug("srtla: \(typeString): Register no group")
+        delegate?.remoteConnectionOnRegNgp(connection: self)
     }
 
     private func handleSrtlaRegNak() {


### PR DESCRIPTION
This allows the client to find a connection that's 1) working and 2) has the lowest RTT, and only then use it to attempt to register the SRTLA connection group

Should improve connection reliability and speed when some (but not all) of the networks are congested or otherwise have high latency. This is essentially the same functionality introduced in srtla_send in 2023 here:

https://github.com/BELABOX/srtla/compare/f0edf2e0c03d08597d2360ecb6eb3fecfb1d535c...f138fb424d9239bc0fe70609c6f43e4963486499

Additionally, we use this to allow clients with connections routed to multiple POPs of our BELABOX cloud anycast network to steer the connection towards a preferred location