### PR TITLE
Added support for Osmo Action 6

### DIFF
--- a/Moblin/Integrations/Dji/DjiDevice/DjiDevice.swift
+++ b/Moblin/Integrations/Dji/DjiDevice/DjiDevice.swift
@@ -324,7 +324,7 @@ extension DjiDevice: CBPeripheralDelegate {
                                              type: configureType,
                                              payload: payload.encode()))
             setState(state: .configuring)
-        case .osmoAction5Pro:
+        case .osmoAction5Pro, .osmoAction6:
             guard let imageStabilization else {
                 return
             }
@@ -357,7 +357,7 @@ extension DjiDevice: CBPeripheralDelegate {
             resolution: resolution,
             fps: fps,
             bitrateKbps: UInt16((bitrate / 1000) & 0xFFFF),
-            oa5: model == .osmoAction5Pro
+            oa5: model == .osmoAction5Pro || .osmoAction6
         )
         writeMessage(message: DjiMessage(target: startStreamingTarget,
                                          id: startStreamingTransactionId,
@@ -368,7 +368,7 @@ extension DjiDevice: CBPeripheralDelegate {
         // This is an exact copy of the stop-streaming command, but the last data-bit in
         // the payload is set to 1 instead of 2.
         // It may probably work fine sending it on all devices, but limiting it to OA5P for now.
-        if model == .osmoAction5Pro {
+        if model == .osmoAction5Pro || model == .osmoAction6 {
             let confirmStartStreamPayload = DjiConfirmStartStreamingMessagePayload()
             writeMessage(message: DjiMessage(target: stopStreamingTarget,
                                              id: stopStreamingTransactionId,

--- a/Moblin/Integrations/Dji/DjiDevice/DjiDeviceModel.swift
+++ b/Moblin/Integrations/Dji/DjiDevice/DjiDeviceModel.swift
@@ -4,6 +4,7 @@ private let djiTechnologyCoLtd = Data([0xAA, 0x08])
 private let djiDeviceModelOsmoAction3 = Data([0x12, 0x00])
 private let djiDeviceModelOsmoAction4 = Data([0x14, 0x00])
 private let djiDeviceModelOsmoAction5Pro = Data([0x15, 0x00])
+private let djiDeviceModelOsmoAction6 = Data([0x18, 0x00])
 private let djiDeviceModelOsmoPocket3 = Data([0x20, 0x00])
 
 func djiModelFromManufacturerData(data: Data) -> SettingsDjiDeviceModel {
@@ -19,6 +20,8 @@ func djiModelFromManufacturerData(data: Data) -> SettingsDjiDeviceModel {
         return .osmoPocket3
     case djiDeviceModelOsmoAction5Pro:
         return .osmoAction5Pro
+    case djiDeviceModelOsmoAction6
+        return .osmoAction6
     default:
         return .unknown
     }

--- a/Moblin/Various/Settings/SettingsDjiDevice.swift
+++ b/Moblin/Various/Settings/SettingsDjiDevice.swift
@@ -62,6 +62,7 @@ enum SettingsDjiDeviceModel: String, Codable {
     case osmoAction3
     case osmoAction4
     case osmoAction5Pro
+    case osmoAction6
     case osmoPocket3
     case unknown
 

--- a/Moblin/View/Settings/DjiDevices/DjiDeviceSettingsView.swift
+++ b/Moblin/View/Settings/DjiDevices/DjiDeviceSettingsView.swift
@@ -244,7 +244,7 @@ private struct DjiDeviceSettingsSettingsView: View {
                 }
             }
             .disabled(device.isStarted)
-            if device.model == .osmoAction4 || device.model == .osmoAction5Pro {
+            if device.model == .osmoAction4 || device.model == .osmoAction5Pro || device.model == .osmoAction6 {
                 Picker("Image stabilization", selection: $device.imageStabilization) {
                     ForEach(SettingsDjiDeviceImageStabilization.allCases, id: \.self) {
                         Text($0.toString())


### PR DESCRIPTION
NB: NOT TESTED. NOT BUILDT.

Quick attempt on adding support for Osmo action 6 into moblin so people can start testing its RTMP capabilities.
Im assuming its using the same protocols as the action 5, so added conditionals for that as well.

Didnt have my macbook available for this 5 min thing, so it may not even build. sorry about that. feel free to reject the PR if it doesnt build at all.

The important part was the device model identifier which was identified to be 0x00, 0x18.