### PR TITLE
added unit test when there is no never timestamp in buffer

### DIFF
--- a/MoblinTests/BufferedAudioSuite.swift
+++ b/MoblinTests/BufferedAudioSuite.swift
@@ -185,7 +185,7 @@ struct BufferedAudioSuite {
         #expect(bufferedAudio.getSampleBuffer(timestamp) === sampleBuffer26)
         #expect(bufferedAudio.numberOfBuffers() == 0)
     }
-    
+
     @Test
     func droppingAllTheFrames() async throws {
         let bufferedAudio = BufferedAudio(cameraId: .init(),


### PR DESCRIPTION
This unit test is a demo why I believe so many frames got dropped. In a situation where no new audio frame is available everything is dropped.

It is not an endless loop - but it discards the whole buffer