### PR TITLE
Add Kick login to stream wizard, matching Twitch pattern.

### DIFF
--- a/Moblin/StreamingPlatforms/Kick/KickAuth.swift
+++ b/Moblin/StreamingPlatforms/Kick/KickAuth.swift
@@ -1,0 +1,113 @@
+import SwiftUI
+import WebKit
+
+private let kickDomain = "kick.com"
+private let loginUrl = URL(string: "https://kick.com/login")!
+private let sessionTokenCookieName = "session_token"
+
+struct KickLoginView: View {
+    @Binding var presenting: Bool
+    let onAccessToken: (String) -> Void
+
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 0) {
+                HStack {
+                    Spacer()
+                    Button("Close") {
+                        presenting = false
+                    }
+                }
+                .padding()
+                KickWebView {
+                    onAccessToken($0)
+                    presenting = false
+                }
+            }
+            .ignoresSafeArea(.keyboard)
+        }
+    }
+}
+
+struct KickWebView: UIViewRepresentable {
+    let onAccessToken: (String) -> Void
+
+    func makeUIView(context: Context) -> WKWebView {
+        let configuration = WKWebViewConfiguration()
+        configuration.websiteDataStore = .nonPersistent()
+        let webView = WKWebView(frame: .zero, configuration: configuration)
+        webView.navigationDelegate = context.coordinator
+        return webView
+    }
+
+    func updateUIView(_ webView: WKWebView, context: Context) {
+        webView.navigationDelegate = context.coordinator
+        guard webView.url?.host()?.contains(kickDomain) != true else {
+            return
+        }
+        webView.load(URLRequest(url: loginUrl))
+        context.coordinator.periodicallyCheckForAccessTokenCookie(webView: webView)
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onAccessToken)
+    }
+
+    class Coordinator: NSObject, WKNavigationDelegate {
+        let onAccessToken: (String) -> Void
+        private var loginButtonClicked = false
+        private let timer = SimpleTimer(queue: .main)
+
+        init(_ onAccessToken: @escaping (String) -> Void) {
+            self.onAccessToken = onAccessToken
+        }
+
+        func webView(_ webView: WKWebView, didFinish _: WKNavigation!) {
+            if !loginButtonClicked {
+                detectAndClickLoginButton(webView)
+            }
+        }
+
+        func periodicallyCheckForAccessTokenCookie(webView: WKWebView) {
+            timer.startPeriodic(interval: 1) { [weak self] in
+                webView.configuration.websiteDataStore.httpCookieStore.getAllCookies { cookies in
+                    guard let sessionTokenCookie = cookies
+                        .filter({ $0.domain.contains(kickDomain) })
+                        .filter({ $0.name == sessionTokenCookieName })
+                        .first
+                    else {
+                        return
+                    }
+                    let accessToken = sessionTokenCookie.value
+                    DispatchQueue.main.async {
+                        self?.onAccessToken(accessToken.removingPercentEncoding ?? accessToken)
+                    }
+                }
+            }
+        }
+
+        private func detectAndClickLoginButton(_ webView: WKWebView) {
+            let detectAndClickLoginButtonScript = """
+            (async function() {
+                try {
+                    // wait for 0.2 second for the page to load
+                    await new Promise(resolve => setTimeout(resolve, 200));
+                    var loginButton = document.querySelector('[data-testid="login"]');
+                    if (loginButton) {
+                        loginButton.click();
+                        return true;
+                    }
+                } catch (error) {
+                    return false;
+                }
+            })();
+            """
+            webView.evaluateJavaScript(detectAndClickLoginButtonScript) { result, error in
+                guard error == nil, result as? Bool == true else {
+                    return
+                }
+                self.loginButtonClicked = true
+            }
+        }
+    }
+}

--- a/Moblin/Various/Model/Model.swift
+++ b/Moblin/Various/Model/Model.swift
@@ -500,6 +500,7 @@ final class Model: NSObject, ObservableObject, @unchecked Sendable {
     var speechToText: SpeechToText?
     let twitchAuth = TwitchAuth()
     var twitchAuthOnComplete: ((_ accessToken: String) -> Void)?
+    var kickAuthOnComplete: ((_ accessToken: String) -> Void)?
     var twitchPlatformStatus: PlatformStatus = .unknown
     let twitchSearchCategoriesTimer = SimpleTimer(queue: .main)
     let kickSearchCategoriesTimer = SimpleTimer(queue: .main)

--- a/Moblin/Various/Model/ModelStream.swift
+++ b/Moblin/Various/Model/ModelStream.swift
@@ -16,13 +16,20 @@ class CreateStreamWizard: ObservableObject {
     let twitchStream = SettingsStream(name: "")
     var twitchAccessToken = ""
     var twitchLoggedIn: Bool = false
+    let kickStream = SettingsStream(name: "")
+    var kickAccessToken = ""
+    var kickLoggedIn: Bool = false
     @Published var presenting = false
     @Published var presentingSetup = false
     @Published var showTwitchAuth = false
+    @Published var showKickAuth = false
     @Published var name = ""
     @Published var twitchChannelName = ""
     @Published var twitchChannelId = ""
     @Published var kickChannelName = ""
+    var kickChannelId: String?
+    var kickSlug: String?
+    var kickChatroomChannelId: String?
     @Published var youTubeHandle = ""
     @Published var soopChannelName = ""
     @Published var soopStreamId = ""

--- a/Moblin/Various/Model/ModelStreamWizard.swift
+++ b/Moblin/Various/Model/ModelStreamWizard.swift
@@ -132,6 +132,11 @@ extension Model {
             }
         case .kick:
             stream.kickChannelName = createStreamWizard.kickChannelName.trim()
+            stream.kickAccessToken = createStreamWizard.kickAccessToken
+            stream.kickLoggedIn = createStreamWizard.kickLoggedIn
+            stream.kickChannelId = createStreamWizard.kickChannelId
+            stream.kickSlug = createStreamWizard.kickSlug
+            stream.kickChatroomChannelId = createStreamWizard.kickChatroomChannelId
         case .youTube:
             stream.youTubeHandle = createStreamWizard.youTubeHandle.trim()
         case .soop:
@@ -174,7 +179,13 @@ extension Model {
         createStreamWizard.twitchChannelName = ""
         createStreamWizard.twitchChannelId = ""
         createStreamWizard.twitchAccessToken = ""
+        createStreamWizard.twitchLoggedIn = false
         createStreamWizard.kickChannelName = ""
+        createStreamWizard.kickAccessToken = ""
+        createStreamWizard.kickLoggedIn = false
+        createStreamWizard.kickChannelId = nil
+        createStreamWizard.kickSlug = nil
+        createStreamWizard.kickChatroomChannelId = nil
         createStreamWizard.youTubeHandle = ""
         createStreamWizard.soopChannelName = ""
         createStreamWizard.soopStreamId = ""

--- a/Moblin/View/Settings/BlackSharkCoolers/BlackSharkCoolerDeviceSettingsView.swift
+++ b/Moblin/View/Settings/BlackSharkCoolers/BlackSharkCoolerDeviceSettingsView.swift
@@ -94,7 +94,8 @@ struct BlackSharkCoolerDeviceSettingsView: View {
                         )
                     } label: {
                         GrayTextView(
-                            text: device.bluetoothPeripheralName ?? String(localized: "Select device"))
+                            text: device.bluetoothPeripheralName ?? String(localized: "Select device")
+                        )
                     }
                     .disabled(device.enabled)
                 } header: {

--- a/Moblin/View/Settings/CyclingPowerDevices/CyclingPowerDeviceSettingsView.swift
+++ b/Moblin/View/Settings/CyclingPowerDevices/CyclingPowerDeviceSettingsView.swift
@@ -55,7 +55,8 @@ struct CyclingPowerDeviceSettingsView: View {
                     )
                     } label: {
                         GrayTextView(
-                            text: device.bluetoothPeripheralName ?? String(localized: "Select device"))
+                            text: device.bluetoothPeripheralName ?? String(localized: "Select device")
+                        )
                     }
                     .disabled(model.isCyclingPowerDeviceEnabled(device: device))
                 } header: {

--- a/Moblin/View/Settings/HeartRateDevices/HeartRateDeviceSettingsView.swift
+++ b/Moblin/View/Settings/HeartRateDevices/HeartRateDeviceSettingsView.swift
@@ -58,7 +58,8 @@ struct HeartRateDeviceSettingsView: View {
                         )
                     } label: {
                         GrayTextView(
-                            text: device.bluetoothPeripheralName ?? String(localized: "Select device"))
+                            text: device.bluetoothPeripheralName ?? String(localized: "Select device")
+                        )
                     }
                     .disabled(model.isHeartRateDeviceEnabled(device: device))
                 } header: {

--- a/Moblin/View/Settings/Streams/Stream/Kick/StreamKickSettingsView.swift
+++ b/Moblin/View/Settings/Streams/Stream/Kick/StreamKickSettingsView.swift
@@ -1,9 +1,4 @@
 import SwiftUI
-import WebKit
-
-private let kickDomain = "kick.com"
-private let loginUrl = URL(string: "https://kick.com/login")!
-private let sessionTokenCookieName = "session_token"
 
 private struct AuthenticationView: View {
     @EnvironmentObject var model: Model
@@ -16,126 +11,19 @@ private struct AuthenticationView: View {
             if !stream.kickLoggedIn {
                 TextButtonView("Login") {
                     presentingWebView = true
+                    model.kickLogin(stream: stream) {
+                        onLoggedIn()
+                    }
                 }
             } else {
                 TextButtonView("Logout") {
-                    logout()
+                    model.kickLogout(stream: stream)
                 }
             }
         }
         .sheet(isPresented: $presentingWebView) {
-            NavigationView {
-                VStack(spacing: 0) {
-                    HStack {
-                        Spacer()
-                        Button("Close") {
-                            presentingWebView = false
-                        }
-                    }
-                    .padding()
-                    KickWebView {
-                        handleAccessToken(accessToken: $0)
-                        presentingWebView = false
-                    }
-                }
-                .ignoresSafeArea(.keyboard)
-            }
-        }
-    }
-
-    private func logout() {
-        stream.kickAccessToken = ""
-        stream.kickLoggedIn = false
-        if stream.enabled {
-            model.kickAccessTokenUpdated()
-        }
-    }
-
-    private func handleAccessToken(accessToken: String) {
-        stream.kickAccessToken = accessToken
-        stream.kickLoggedIn = true
-        onLoggedIn()
-    }
-}
-
-private struct KickWebView: UIViewRepresentable {
-    let onAccessToken: (String) -> Void
-
-    func makeUIView(context: Context) -> WKWebView {
-        let configuration = WKWebViewConfiguration()
-        configuration.websiteDataStore = .nonPersistent()
-        let webView = WKWebView(frame: .zero, configuration: configuration)
-        webView.navigationDelegate = context.coordinator
-        return webView
-    }
-
-    func updateUIView(_ webView: WKWebView, context: Context) {
-        webView.navigationDelegate = context.coordinator
-        guard webView.url?.host()?.contains(kickDomain) != true else {
-            return
-        }
-        webView.load(URLRequest(url: loginUrl))
-        context.coordinator.periodicallyCheckForAccessTokenCookie(webView: webView)
-    }
-
-    func makeCoordinator() -> Coordinator {
-        Coordinator(onAccessToken)
-    }
-
-    class Coordinator: NSObject, WKNavigationDelegate {
-        let onAccessToken: (String) -> Void
-        private var loginButtonClicked = false
-        private let timer = SimpleTimer(queue: .main)
-
-        init(_ onAccessToken: @escaping (String) -> Void) {
-            self.onAccessToken = onAccessToken
-        }
-
-        func webView(_ webView: WKWebView, didFinish _: WKNavigation!) {
-            if !loginButtonClicked {
-                detectAndClickLoginButton(webView)
-            }
-        }
-
-        func periodicallyCheckForAccessTokenCookie(webView: WKWebView) {
-            timer.startPeriodic(interval: 1) { [weak self] in
-                webView.configuration.websiteDataStore.httpCookieStore.getAllCookies { cookies in
-                    guard let sessionTokenCookie = cookies
-                        .filter({ $0.domain.contains(kickDomain) })
-                        .filter({ $0.name == sessionTokenCookieName })
-                        .first
-                    else {
-                        return
-                    }
-                    let accessToken = sessionTokenCookie.value
-                    DispatchQueue.main.async {
-                        self?.onAccessToken(accessToken.removingPercentEncoding ?? accessToken)
-                    }
-                }
-            }
-        }
-
-        private func detectAndClickLoginButton(_ webView: WKWebView) {
-            let detectAndClickLoginButtonScript = """
-            (async function() {
-                try {
-                    // wait for 0.2 second for the page to load
-                    await new Promise(resolve => setTimeout(resolve, 200));
-                    var loginButton = document.querySelector('[data-testid="login"]');
-                    if (loginButton) {
-                        loginButton.click();
-                        return true;
-                    }
-                } catch (error) {
-                    return false;
-                }
-            })();
-            """
-            webView.evaluateJavaScript(detectAndClickLoginButtonScript) { result, error in
-                guard error == nil, result as? Bool == true else {
-                    return
-                }
-                self.loginButtonClicked = true
+            KickLoginView(presenting: $presentingWebView) { accessToken in
+                model.kickAuthOnComplete?(accessToken)
             }
         }
     }

--- a/Moblin/View/Settings/Streams/Stream/Wizard/Platform/StreamWizardKickSettingsView.swift
+++ b/Moblin/View/Settings/Streams/Stream/Wizard/Platform/StreamWizardKickSettingsView.swift
@@ -4,16 +4,37 @@ struct StreamWizardKickSettingsView: View {
     @EnvironmentObject private var model: Model
     @ObservedObject var createStreamWizard: CreateStreamWizard
 
-    private func channelName() -> String {
-        return createStreamWizard.kickChannelName.trim()
+    private func nextDisabled() -> Bool {
+        return createStreamWizard.kickChannelName.trim().isEmpty
     }
 
-    private func nextDisabled() -> Bool {
-        return channelName().isEmpty
+    private func onLoginComplete() {
+        createStreamWizard.kickChannelName = createStreamWizard.kickStream.kickChannelName
+        createStreamWizard.kickAccessToken = createStreamWizard.kickStream.kickAccessToken
+        createStreamWizard.kickLoggedIn = createStreamWizard.kickStream.kickLoggedIn
+        createStreamWizard.kickChannelId = createStreamWizard.kickStream.kickChannelId
+        createStreamWizard.kickSlug = createStreamWizard.kickStream.kickSlug
+        createStreamWizard.kickChatroomChannelId = createStreamWizard.kickStream.kickChatroomChannelId
     }
 
     var body: some View {
         Form {
+            Section {
+                if createStreamWizard.kickStream.kickAccessToken.isEmpty {
+                    TextButtonView("Login") {
+                        createStreamWizard.showKickAuth = true
+                        model.kickLogin(stream: createStreamWizard.kickStream) {
+                            onLoginComplete()
+                        }
+                    }
+                } else {
+                    TextButtonView("Logout") {
+                        model.kickLogout(stream: createStreamWizard.kickStream)
+                    }
+                }
+            } footer: {
+                Text("Optional, but simplifies the setup.")
+            }
             Section {
                 TextField("MyChannel", text: $createStreamWizard.kickChannelName)
                     .disableAutocorrection(true)
@@ -32,11 +53,17 @@ struct StreamWizardKickSettingsView: View {
                 .disabled(nextDisabled())
             }
         }
+        .sheet(isPresented: $createStreamWizard.showKickAuth) {
+            KickLoginView(presenting: $createStreamWizard.showKickAuth) { accessToken in
+                model.kickAuthOnComplete?(accessToken)
+            }
+        }
         .onAppear {
             createStreamWizard.platform = .kick
             createStreamWizard.name = makeUniqueName(name: String(localized: "Kick"),
                                                      existingNames: model.database.streams)
             createStreamWizard.directIngest = ""
+            createStreamWizard.kickStream.kickAccessToken = ""
         }
         .navigationTitle("Kick")
         .toolbar {


### PR DESCRIPTION
 Changes:
  - Add KickAuth.swift - shared login view (extracted from settings)
  - Add kickLogin()/kickLogout() to Model
  - Update wizard to include Login/Logout buttons
  - Save Kick login data when creating stream from wizard