### PR TITLE
Fix logger being initialized with old unused setting

### DIFF
--- a/Moblin/Various/Model/Model.swift
+++ b/Moblin/Various/Model/Model.swift
@@ -980,7 +980,7 @@ final class Model: NSObject, ObservableObject, @unchecked Sendable {
         SDImageCodersManager.shared.addCoder(webPCoder)
         UIDevice.current.isBatteryMonitoringEnabled = true
         logger.handler = debugLog(message:)
-        logger.debugEnabled = database.debug.logLevel == .debug
+        logger.debugEnabled = database.debug.debugLogging
         updateCameraLists()
         updateBatteryLevel()
         setPixelFormat()


### PR DESCRIPTION
Since logLevel was replaced by debugLogging in other places and the code doesn't use anything more than info and debug, I wonder if we should keep the SettingsLogLevel enum unused (maybe we find use for .error) or remove logLevel altogether