### PR TITLE
Add Meta Glasses camera source integration

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,9 @@
+{
+  "servers": {
+    "xcode": {
+      "type": "stdio",
+      "command": "xcrun",
+      "args": ["mcpbridge"]
+    }
+  }
+}

--- a/Moblin.xcodeproj/project.pbxproj
+++ b/Moblin.xcodeproj/project.pbxproj
@@ -38,6 +38,9 @@
 		03ECDF5D2B8E5F0B00BD920E /* WrappingHStack in Frameworks */ = {isa = PBXBuildFile; productRef = 03ECDF5C2B8E5F0B00BD920E /* WrappingHStack */; };
 		03F465EC2C441D1400630708 /* CrcSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 03F465EB2C441D1400630708 /* CrcSwift */; };
 		882D0C162DF76F5B0035BFAF /* BlackSharkLib in Frameworks */ = {isa = PBXBuildFile; productRef = 882D0C152DF76F5B0035BFAF /* BlackSharkLib */; };
+		B50B505C2F5D3CCA008FD12C /* MWDATCamera in Frameworks */ = {isa = PBXBuildFile; productRef = B50B505B2F5D3CCA008FD12C /* MWDATCamera */; };
+		B50B505E2F5D3CCA008FD12C /* MWDATCore in Frameworks */ = {isa = PBXBuildFile; productRef = B50B505D2F5D3CCA008FD12C /* MWDATCore */; };
+		B50B50602F5D3CCA008FD12C /* MWDATMockDevice in Frameworks */ = {isa = PBXBuildFile; productRef = B50B505F2F5D3CCA008FD12C /* MWDATMockDevice */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -253,6 +256,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				03B7DAB52BA640C100CEFC1B /* XMLCoder in Frameworks */,
+				B50B505C2F5D3CCA008FD12C /* MWDATCamera in Frameworks */,
 				033BEAC42C0FCC0B005F4E06 /* NWWebSocket in Frameworks */,
 				03BC11672AE5654700C38FC4 /* SDWebImageSwiftUI in Frameworks */,
 				0318D36A2CF51D6900E12F3B /* SwiftProtobuf in Frameworks */,
@@ -274,6 +278,7 @@
 				0377239C2DE35191007D040D /* VRMSceneKit in Frameworks */,
 				0375F6E92F535715005BE7A8 /* Rist in Frameworks */,
 				03BC116B2AE56C2200C38FC4 /* SDWebImageWebPCoder in Frameworks */,
+				B50B505E2F5D3CCA008FD12C /* MWDATCore in Frameworks */,
 				03D5A1C22F5A600100A1B2C3 /* (null) in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -291,6 +296,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B50B50602F5D3CCA008FD12C /* MWDATMockDevice in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -413,6 +419,8 @@
 				0375F6EB2F53844C005BE7A8 /* DataChannel */,
 				0375F6EE2F539602005BE7A8 /* Srt */,
 				0375FD7A2F539AAC005BE7A8 /* Srt */,
+				B50B505B2F5D3CCA008FD12C /* MWDATCamera */,
+				B50B505D2F5D3CCA008FD12C /* MWDATCore */,
 			);
 			productName = Mobs;
 			productReference = 035E9E332A9A02D6009D4F5A /* Moblin.app */;
@@ -456,6 +464,7 @@
 			);
 			name = MoblinTests;
 			packageProductDependencies = (
+				B50B505F2F5D3CCA008FD12C /* MWDATMockDevice */,
 			);
 			productName = MoblinTests;
 			productReference = 03E649432E634D2800728501 /* MoblinTests.xctest */;
@@ -570,6 +579,7 @@
 				0375F6E72F535715005BE7A8 /* XCRemoteSwiftPackageReference "Rist" */,
 				0375F6EA2F53844B005BE7A8 /* XCRemoteSwiftPackageReference "DataChannel" */,
 				0375FD792F539AAC005BE7A8 /* XCRemoteSwiftPackageReference "SrtSwift" */,
+				B50B505A2F5D3CCA008FD12C /* XCRemoteSwiftPackageReference "meta-wearables-dat-ios" */,
 			);
 			productRefGroup = 035E9E342A9A02D6009D4F5A /* Products */;
 			projectDirPath = "";
@@ -923,7 +933,7 @@
 				INFOPLIST_KEY_CFBundleDisplayName = Moblin;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.video";
-				INFOPLIST_KEY_NSBluetoothAlwaysUsageDescription = "Moblin communicates with DJI cameras using Bluetooth.";
+				INFOPLIST_KEY_NSBluetoothAlwaysUsageDescription = "Moblin communicates with cameras using Bluetooth.";
 				INFOPLIST_KEY_NSCameraUsageDescription = "Moblin live streams video from the camera.";
 				INFOPLIST_KEY_NSHealthClinicalHealthRecordsShareUsageDescription = "Moblin can show your heart rate on stream.";
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "Moblin can show your heart rate on stream.";
@@ -992,7 +1002,7 @@
 				INFOPLIST_KEY_CFBundleDisplayName = Moblin;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.video";
-				INFOPLIST_KEY_NSBluetoothAlwaysUsageDescription = "Moblin communicates with DJI cameras using Bluetooth.";
+				INFOPLIST_KEY_NSBluetoothAlwaysUsageDescription = "Moblin communicates with cameras using Bluetooth.";
 				INFOPLIST_KEY_NSCameraUsageDescription = "Moblin live streams video from the camera.";
 				INFOPLIST_KEY_NSHealthClinicalHealthRecordsShareUsageDescription = "Moblin can show your heart rate on stream.";
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "Moblin can show your heart rate on stream.";
@@ -1428,6 +1438,14 @@
 				minimumVersion = 1.1.1;
 			};
 		};
+		B50B505A2F5D3CCA008FD12C /* XCRemoteSwiftPackageReference "meta-wearables-dat-ios" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/facebook/meta-wearables-dat-ios";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.4.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1548,6 +1566,21 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 882D0C142DF76F5B0035BFAF /* XCRemoteSwiftPackageReference "BlackSharkLib" */;
 			productName = BlackSharkLib;
+		};
+		B50B505B2F5D3CCA008FD12C /* MWDATCamera */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B50B505A2F5D3CCA008FD12C /* XCRemoteSwiftPackageReference "meta-wearables-dat-ios" */;
+			productName = MWDATCamera;
+		};
+		B50B505D2F5D3CCA008FD12C /* MWDATCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B50B505A2F5D3CCA008FD12C /* XCRemoteSwiftPackageReference "meta-wearables-dat-ios" */;
+			productName = MWDATCore;
+		};
+		B50B505F2F5D3CCA008FD12C /* MWDATMockDevice */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B50B505A2F5D3CCA008FD12C /* XCRemoteSwiftPackageReference "meta-wearables-dat-ios" */;
+			productName = MWDATMockDevice;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Moblin.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Moblin.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "75c04dc272d23930ef4db707876baa41c267fbbc75ffeb482851868e6e5d71d4",
+  "originHash" : "c886fa645cefd1c7d0603aeea4be4c7ae07ac4b1dc43fad2c67ab17aa347fea4",
   "pins" : [
     {
       "identity" : "alerttoast",
@@ -53,6 +53,15 @@
       "state" : {
         "revision" : "0d60654eeefd5d7d2bef3835804892c40225e8b2",
         "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "meta-wearables-dat-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/facebook/meta-wearables-dat-ios",
+      "state" : {
+        "revision" : "b67454b6f081373f757476ecb3b4973bf33bc326",
+        "version" : "0.4.0"
       }
     },
     {

--- a/Moblin/Info.plist
+++ b/Moblin/Info.plist
@@ -19,6 +19,27 @@
 	</array>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>MWDAT</key>
+	<dict>
+		<key>AppLinkURLScheme</key>
+		<string>moblin://</string>
+		<key>ClientToken</key>
+		<string>$(MWDAT_CLIENT_TOKEN)</string>
+		<key>MetaAppID</key>
+		<string>$(MWDAT_META_APP_ID)</string>
+		<key>TeamID</key>
+		<string>$(DEVELOPMENT_TEAM)</string>
+		<key>Analytics</key>
+		<dict>
+			<key>OptOut</key>
+			<true/>
+		</dict>
+	</dict>
+	<!-- External Accessory protocol for Meta Wearables -->
+	<key>UISupportedExternalAccessoryProtocols</key>
+	<array>
+		<string>com.meta.ar.wearable</string>
+	</array>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
@@ -44,34 +65,34 @@
 	</array>
 	<key>UIFileSharingEnabled</key>
 	<true/>
-    <key>UIApplicationSceneManifest</key>
-    <dict>
-            <key>UIApplicationSupportsMultipleScenes</key>
-            <true/>
-            <key>UISceneConfigurations</key>
-            <dict>
-                    <key>UIWindowSceneSessionRoleExternalDisplayNonInteractive</key>
-                    <array>
-                            <dict>
-                                    <key>UISceneDelegateClassName</key>
-                                    <string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<true/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleExternalDisplayNonInteractive</key>
+			<array>
+				<dict>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
                                     <key>UISceneConfigurationName</key>
                                     <string>External Display</string>
-                            </dict>
-                    </array>
-            </dict>
-    </dict>
+				</dict>
+			</array>
+		</dict>
+	</dict>
     <key>CFBundleIdentifier</key>
     <string></string>
-    <key>WiFiAwareServices</key>
-    <dict>
-        <key>_moblin._udp</key>
-        <dict>
-            <key>Publishable</key>
-            <dict/>
-            <key>Subscribable</key>
-            <dict/>
-        </dict>
-    </dict>
+	<key>WiFiAwareServices</key>
+	<dict>
+		<key>_moblin._udp</key>
+		<dict>
+			<key>Publishable</key>
+			<dict/>
+			<key>Subscribable</key>
+			<dict/>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/Moblin/InfoPlist.xcstrings
+++ b/Moblin/InfoPlist.xcstrings
@@ -139,67 +139,67 @@
       "localizations" : {
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Moblin kommuniziert mit DJI-Kameras über Bluetooth."
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Moblin communicates with DJI cameras using Bluetooth."
+            "value" : "Moblin communicates with cameras using Bluetooth."
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Moblin communique avec les caméras DJI par Bluetooth"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Moblin tcomunica con DJI usando il Bluetooth."
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Moblin communiceert met DJI-camera's via Bluetooth."
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Moblin komunikuje się z kamerami DJI przez Bluetooth"
           }
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Moblin использует Bluetooth для подключения к камерам DJI"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Moblin Bluetooth'u DJI kameraları için kullanır."
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Moblin 使用藍芽與 DJI 設備進行連線"
           }
         },
         "zh-Hant-TW" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Moblin 需使用藍牙與 DJI 相機進行通訊。"
           }
         },
         "zh-HK" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Moblin使用藍牙和DJI裝置進行通訊"
           }
         }

--- a/Moblin/Integrations/MetaGlasses/MetaGlassesDevice.swift
+++ b/Moblin/Integrations/MetaGlasses/MetaGlassesDevice.swift
@@ -5,16 +5,38 @@ import MWDATCore
 
 private let metaGlassesStreamLatency = 0.1
 
-enum MetaGlassesRegistrationState: String {
-    case unregistered = "Unregistered"
-    case registering = "Registering..."
-    case registered = "Registered"
+enum MetaGlassesRegistrationState {
+    case unregistered
+    case registering
+    case registered
+
+    func toString() -> String {
+        switch self {
+        case .unregistered:
+            return String(localized: "Unregistered")
+        case .registering:
+            return String(localized: "Registering...")
+        case .registered:
+            return String(localized: "Registered")
+        }
+    }
 }
 
-enum MetaGlassesStreamingState: String {
-    case stopped = "Stopped"
-    case waiting = "Waiting..."
-    case streaming = "Streaming"
+enum MetaGlassesStreamingState {
+    case stopped
+    case waiting
+    case streaming
+
+    func toString() -> String {
+        switch self {
+        case .stopped:
+            return String(localized: "Stopped")
+        case .waiting:
+            return String(localized: "Waiting...")
+        case .streaming:
+            return String(localized: "Streaming")
+        }
+    }
 }
 
 protocol MetaGlassesDeviceDelegate: AnyObject {
@@ -56,7 +78,7 @@ class MetaGlassesDevice {
             wearables = Wearables.shared
             isConfigured = true
         } catch {
-            delegate?.metaGlassesDeviceError("Failed to configure Meta Wearables SDK: \(error)")
+            logger.info("meta-glasses: Failed to configure MWDAT SDK: \(error)")
         }
     }
 
@@ -97,9 +119,9 @@ class MetaGlassesDevice {
             do {
                 try await wearables.startRegistration()
             } catch let error as RegistrationError {
-                self.delegate?.metaGlassesDeviceError("Registration failed: \(error.description)")
+                self.delegate?.metaGlassesDeviceError(String(localized: "Registration failed: \(error.description)"))
             } catch {
-                self.delegate?.metaGlassesDeviceError("Registration failed: \(error.localizedDescription)")
+                self.delegate?.metaGlassesDeviceError(String(localized: "Registration failed: \(error.localizedDescription)"))
             }
         }
     }
@@ -112,7 +134,7 @@ class MetaGlassesDevice {
                 try await wearables.startUnregistration()
             } catch {
                 self.delegate?.metaGlassesDeviceError(
-                    "Disconnect failed: \(error.localizedDescription)")
+                    String(localized: "Disconnect failed: \(error.localizedDescription)"))
             }
         }
     }
@@ -215,10 +237,10 @@ class MetaGlassesDevice {
             if requestStatus == .granted {
                 await session.start()
             } else {
-                delegate?.metaGlassesDeviceError("Camera permission denied")
+                delegate?.metaGlassesDeviceError(String(localized: "Camera permission denied"))
             }
         } catch {
-            delegate?.metaGlassesDeviceError("Permission error: \(error.localizedDescription)")
+            delegate?.metaGlassesDeviceError(String(localized: "Permission error: \(error.localizedDescription)"))
         }
     }
 
@@ -240,23 +262,23 @@ class MetaGlassesDevice {
         let message: String
         switch error {
         case .internalError:
-            message = "Internal streaming error"
+            message = String(localized: "Internal streaming error")
         case .deviceNotFound:
-            message = "Glasses not found"
+            message = String(localized: "Glasses not found")
         case .deviceNotConnected:
-            message = "Glasses not connected"
+            message = String(localized: "Glasses not connected")
         case .timeout:
-            message = "Connection timed out"
+            message = String(localized: "Connection timed out")
         case .videoStreamingError:
-            message = "Video streaming failed"
+            message = String(localized: "Video streaming failed")
         case .audioStreamingError:
-            message = "Audio streaming failed"
+            message = String(localized: "Audio streaming failed")
         case .permissionDenied:
-            message = "Camera permission denied"
+            message = String(localized: "Camera permission denied")
         case .hingesClosed:
-            message = "Glasses hinges are closed"
+            message = String(localized: "Glasses hinges are closed")
         @unknown default:
-            message = "Unknown streaming error"
+            message = String(localized: "Unknown streaming error")
         }
         delegate?.metaGlassesDeviceError(message)
     }

--- a/Moblin/Integrations/MetaGlasses/MetaGlassesDevice.swift
+++ b/Moblin/Integrations/MetaGlasses/MetaGlassesDevice.swift
@@ -1,0 +1,274 @@
+import CoreMedia
+import Foundation
+import MWDATCamera
+import MWDATCore
+
+private let metaGlassesStreamLatency = 0.1
+
+enum MetaGlassesRegistrationState: String {
+    case unregistered = "Unregistered"
+    case registering = "Registering..."
+    case registered = "Registered"
+}
+
+enum MetaGlassesStreamingState: String {
+    case stopped = "Stopped"
+    case waiting = "Waiting..."
+    case streaming = "Streaming"
+}
+
+protocol MetaGlassesDeviceDelegate: AnyObject {
+    func metaGlassesDeviceConnected()
+    func metaGlassesDeviceDisconnected()
+    func metaGlassesDeviceVideoBuffer(_ sampleBuffer: CMSampleBuffer)
+    func metaGlassesDeviceRegistrationStateChanged(_ state: MetaGlassesRegistrationState)
+    func metaGlassesDeviceStreamingStateChanged(_ state: MetaGlassesStreamingState)
+    func metaGlassesDeviceError(_ message: String)
+}
+
+class MetaGlassesDevice {
+    weak var delegate: MetaGlassesDeviceDelegate?
+
+    private var wearables: WearablesInterface?
+    private var streamSession: StreamSession?
+    private var deviceSelector: AutoDeviceSelector?
+    private var stateListenerToken: AnyListenerToken?
+    private var videoFrameListenerToken: AnyListenerToken?
+    private var errorListenerToken: AnyListenerToken?
+    private var registrationTask: Task<Void, Never>?
+    private var deviceStreamTask: Task<Void, Never>?
+    private var deviceMonitorTask: Task<Void, Never>?
+    private(set) var registrationState: MetaGlassesRegistrationState = .unregistered
+    private(set) var streamingState: MetaGlassesStreamingState = .stopped
+    private(set) var hasActiveDevice = false
+    private(set) var isConfigured = false
+
+    init() {}
+
+    deinit {
+        stop()
+    }
+
+    func configure() {
+        guard !isConfigured else { return }
+        do {
+            try Wearables.configure()
+            wearables = Wearables.shared
+            isConfigured = true
+        } catch {
+            delegate?.metaGlassesDeviceError("Failed to configure Meta Wearables SDK: \(error)")
+        }
+    }
+
+    func start() {
+        guard isConfigured, let wearables else { return }
+
+        registrationTask = Task { @MainActor in
+            for await state in wearables.registrationStateStream() {
+                self.updateRegistrationState(state)
+            }
+        }
+
+        deviceStreamTask = Task { @MainActor in
+            for await _ in wearables.devicesStream() {
+                // Device list updated
+            }
+        }
+    }
+
+    func stop() {
+        stopStreaming()
+        registrationTask?.cancel()
+        registrationTask = nil
+        deviceStreamTask?.cancel()
+        deviceStreamTask = nil
+    }
+
+    func handleUrl(_ url: URL) async throws {
+        guard isConfigured else { return }
+        _ = try await Wearables.shared.handleUrl(url)
+    }
+
+    // MARK: - Registration
+
+    func connectGlasses() {
+        guard let wearables, registrationState != .registering else { return }
+        Task { @MainActor in
+            do {
+                try await wearables.startRegistration()
+            } catch let error as RegistrationError {
+                self.delegate?.metaGlassesDeviceError("Registration failed: \(error.description)")
+            } catch {
+                self.delegate?.metaGlassesDeviceError("Registration failed: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    func disconnectGlasses() {
+        guard let wearables else { return }
+        stopStreaming()
+        Task { @MainActor in
+            do {
+                try await wearables.startUnregistration()
+            } catch {
+                self.delegate?.metaGlassesDeviceError(
+                    "Disconnect failed: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    // MARK: - Streaming
+
+    func startStreaming(resolution: SettingsMetaGlassesResolution, frameRate: Int) {
+        guard let wearables, registrationState == .registered else { return }
+
+        let sdkResolution = mapResolution(resolution)
+        let sdkFrameRate = UInt(frameRate)
+
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            let selector = AutoDeviceSelector(wearables: wearables)
+            self.deviceSelector = selector
+
+            let config = StreamSessionConfig(
+                videoCodec: VideoCodec.raw,
+                resolution: sdkResolution,
+                frameRate: sdkFrameRate
+            )
+            let session = StreamSession(streamSessionConfig: config, deviceSelector: selector)
+            self.streamSession = session
+
+            self.deviceMonitorTask = Task { @MainActor in
+                for await device in selector.activeDeviceStream() {
+                    let wasActive = self.hasActiveDevice
+                    self.hasActiveDevice = device != nil
+                    if self.hasActiveDevice, !wasActive {
+                        self.delegate?.metaGlassesDeviceConnected()
+                    } else if !self.hasActiveDevice, wasActive {
+                        self.delegate?.metaGlassesDeviceDisconnected()
+                    }
+                }
+            }
+
+            self.stateListenerToken = session.statePublisher.listen { [weak self] state in
+                Task { @MainActor [weak self] in
+                    self?.handleStreamStateChange(state)
+                }
+            }
+
+            self.videoFrameListenerToken = session.videoFramePublisher.listen { [weak self] (videoFrame: VideoFrame) in
+                let sampleBuffer = videoFrame.sampleBuffer
+                self?.delegate?.metaGlassesDeviceVideoBuffer(sampleBuffer)
+            }
+
+            self.errorListenerToken = session.errorPublisher.listen { [weak self] error in
+                Task { @MainActor [weak self] in
+                    self?.handleStreamError(error)
+                }
+            }
+
+            await self.checkPermissionsAndStart(session: session)
+        }
+    }
+
+    func stopStreaming() {
+        guard let session = streamSession else { return }
+        stateListenerToken = nil
+        videoFrameListenerToken = nil
+        errorListenerToken = nil
+        deviceMonitorTask?.cancel()
+        deviceMonitorTask = nil
+        Task {
+            await session.stop()
+        }
+        streamSession = nil
+        deviceSelector = nil
+        streamingState = .stopped
+        delegate?.metaGlassesDeviceStreamingStateChanged(.stopped)
+    }
+
+    // MARK: - Private
+
+    private func updateRegistrationState(_ state: RegistrationState) {
+        switch state {
+        case .registered:
+            registrationState = .registered
+        case .registering:
+            registrationState = .registering
+        case .unavailable, .available:
+            registrationState = .unregistered
+        @unknown default:
+            registrationState = .unregistered
+        }
+        delegate?.metaGlassesDeviceRegistrationStateChanged(registrationState)
+    }
+
+    private func checkPermissionsAndStart(session: StreamSession) async {
+        guard let wearables else { return }
+        do {
+            let status = try await wearables.checkPermissionStatus(.camera)
+            if status == .granted {
+                await session.start()
+                return
+            }
+            let requestStatus = try await wearables.requestPermission(.camera)
+            if requestStatus == .granted {
+                await session.start()
+            } else {
+                delegate?.metaGlassesDeviceError("Camera permission denied")
+            }
+        } catch {
+            delegate?.metaGlassesDeviceError("Permission error: \(error.localizedDescription)")
+        }
+    }
+
+    private func handleStreamStateChange(_ state: StreamSessionState) {
+        switch state {
+        case .stopped:
+            streamingState = .stopped
+        case .waitingForDevice, .starting, .stopping, .paused:
+            streamingState = .waiting
+        case .streaming:
+            streamingState = .streaming
+        @unknown default:
+            streamingState = .stopped
+        }
+        delegate?.metaGlassesDeviceStreamingStateChanged(streamingState)
+    }
+
+    private func handleStreamError(_ error: StreamSessionError) {
+        let message: String
+        switch error {
+        case .internalError:
+            message = "Internal streaming error"
+        case .deviceNotFound:
+            message = "Glasses not found"
+        case .deviceNotConnected:
+            message = "Glasses not connected"
+        case .timeout:
+            message = "Connection timed out"
+        case .videoStreamingError:
+            message = "Video streaming failed"
+        case .audioStreamingError:
+            message = "Audio streaming failed"
+        case .permissionDenied:
+            message = "Camera permission denied"
+        case .hingesClosed:
+            message = "Glasses hinges are closed"
+        @unknown default:
+            message = "Unknown streaming error"
+        }
+        delegate?.metaGlassesDeviceError(message)
+    }
+
+    private func mapResolution(_ resolution: SettingsMetaGlassesResolution) -> StreamingResolution {
+        switch resolution {
+        case .low:
+            return .low
+        case .medium:
+            return .medium
+        case .high:
+            return .high
+        }
+    }
+}

--- a/Moblin/MoblinApp.swift
+++ b/Moblin/MoblinApp.swift
@@ -81,7 +81,22 @@ class SceneDelegate: NSObject, UIWindowSceneDelegate {
     }
 
     func scene(_: UIScene, openURLContexts urlContexts: Set<UIOpenURLContext>) {
-        MoblinApp.globalModel?.handleSettingsUrls(urls: urlContexts)
+        guard let model = MoblinApp.globalModel else {
+            return
+        }
+        var settingsUrlContexts = Set<UIOpenURLContext>()
+        for urlContext in urlContexts {
+            if let components = URLComponents(url: urlContext.url, resolvingAgainstBaseURL: false),
+               components.queryItems?.contains(where: { $0.name == "metaWearablesAction" }) == true
+            {
+                model.handleMetaGlassesUrl(urlContext.url)
+            } else {
+                settingsUrlContexts.insert(urlContext)
+            }
+        }
+        if !settingsUrlContexts.isEmpty {
+            model.handleSettingsUrls(urls: settingsUrlContexts)
+        }
     }
 }
 

--- a/Moblin/Various/Model/Model.swift
+++ b/Moblin/Various/Model/Model.swift
@@ -39,6 +39,7 @@ enum ShowingPanel {
     case djiDevices
     case sceneSettings
     case goPro
+    case metaGlasses
     case connectionPriorities
     case autoSceneSwitcher
     case quickButtonSettings
@@ -308,6 +309,11 @@ class GoProState: ObservableObject {
     @Published var rtmpUrlSelection: UUID?
 }
 
+class MetaGlassesState: ObservableObject {
+    @Published var registrationState: MetaGlassesRegistrationState = .unregistered
+    @Published var streamingState: MetaGlassesStreamingState = .stopped
+}
+
 class QuickButtons: ObservableObject {
     @Published var pairs: [[QuickButtonPair]] = Array(repeating: [], count: controlBarPages)
     @Published var selectedButtonType: SettingsQuickButtonType?
@@ -402,6 +408,8 @@ final class Model: NSObject, ObservableObject, @unchecked Sendable {
     let quickButtons = QuickButtons()
     let mic = Mic()
     let goPro = GoProState()
+    let metaGlasses = MetaGlassesState()
+    let metaGlassesDevice = MetaGlassesDevice()
     let obsQuickButton = QuickButtonObs()
     let streamingHistory = StreamingHistory()
     let quickButtonChatState = QuickButtonChat()
@@ -754,6 +762,7 @@ final class Model: NSObject, ObservableObject, @unchecked Sendable {
             .obs,
             .djiDevices,
             .goPro,
+            .metaGlasses,
             .connectionPriorities,
             .autoSceneSwitcher,
             .live,
@@ -1145,6 +1154,7 @@ final class Model: NSObject, ObservableObject, @unchecked Sendable {
         goPro.launchLiveStreamSelection = database.goPro.selectedLaunchLiveStream
         goPro.wifiCredentialsSelection = database.goPro.selectedWifiCredentials
         goPro.rtmpUrlSelection = database.goPro.selectedRtmpUrl
+        setupMetaGlasses()
         replay.speed = database.replay.speed
         gForceManager = GForceManager(motionManager: motionManager)
         startGForceManager()

--- a/Moblin/Various/Model/ModelCamera.swift
+++ b/Moblin/Various/Model/ModelCamera.swift
@@ -576,6 +576,7 @@ extension Model {
             ($0.0.uuidString, $0.1)
         }
         cameras.append((screenCaptureCamera, screenCaptureCamera))
+        cameras.append((metaGlassesCamera, metaGlassesCamera))
         cameras.append((noneCamera, noneCamera))
         return cameras
     }
@@ -643,6 +644,8 @@ extension Model {
             return .backWideDualLowEnergy
         } else if isNoneCamera(cameraId: cameraId) {
             return .none
+        } else if isMetaGlassesCamera(cameraId: cameraId) {
+            return .metaGlasses
         } else {
             return .external(id: cameraId, name: getExternalCameraName(cameraId: cameraId))
         }
@@ -673,6 +676,8 @@ extension Model {
             return id
         case .screenCapture:
             return screenCaptureCamera
+        case .metaGlasses:
+            return metaGlassesCamera
         case .backTripleLowEnergy:
             return backTripleLowEnergyCamera
         case .backDualLowEnergy:
@@ -737,6 +742,8 @@ extension Model {
             }
         case .screenCapture:
             return screenCaptureCamera
+        case .metaGlasses:
+            return metaGlassesCamera
         case .backTripleLowEnergy:
             return backTripleLowEnergyCamera
         case .backDualLowEnergy:
@@ -830,6 +837,8 @@ extension Model {
             return id
         case .screenCapture:
             return screenCaptureCameraId
+        case .metaGlasses:
+            return metaGlassesCameraId
         case let .back(id: id):
             return getBuiltinCameraId(id)
         case let .front(id: id):

--- a/Moblin/Various/Model/ModelMetaGlasses.swift
+++ b/Moblin/Various/Model/ModelMetaGlasses.swift
@@ -1,0 +1,121 @@
+import CoreMedia
+import Foundation
+
+let metaGlassesCameraId = UUID(uuidString: "00000000-AE7A-9145-BEEF-000000000000")!
+let metaGlassesCamera = "Meta glasses"
+private let metaGlassesStreamLatency = 0.1
+
+extension Model: MetaGlassesDeviceDelegate {
+    func isMetaGlassesCamera(cameraId: String) -> Bool {
+        return cameraId == metaGlassesCamera
+    }
+
+    func setupMetaGlasses() {
+        metaGlassesDevice.delegate = self
+        if database.metaGlasses.enabled {
+            metaGlassesDevice.configure()
+            metaGlassesDevice.start()
+        }
+    }
+
+    func reloadMetaGlasses() {
+        if database.metaGlasses.enabled {
+            metaGlassesDevice.configure()
+            metaGlassesDevice.start()
+        } else {
+            metaGlassesDevice.stop()
+            media.removeBufferedVideo(cameraId: metaGlassesCameraId)
+        }
+    }
+
+    func startMetaGlassesStreaming() {
+        media.addBufferedVideo(
+            cameraId: metaGlassesCameraId,
+            name: metaGlassesCamera,
+            latency: metaGlassesStreamLatency
+        )
+        metaGlassesDevice.startStreaming(
+            resolution: database.metaGlasses.resolution,
+            frameRate: database.metaGlasses.frameRate
+        )
+    }
+
+    func startMetaGlassesStreamingIfRegistered() {
+        guard metaGlasses.registrationState == .registered,
+              metaGlasses.streamingState == .stopped
+        else {
+            return
+        }
+        startMetaGlassesStreaming()
+    }
+
+    func stopMetaGlassesStreaming() {
+        metaGlassesDevice.stopStreaming()
+        media.removeBufferedVideo(cameraId: metaGlassesCameraId)
+    }
+
+    func stopMetaGlassesStreamingIfActive() {
+        guard metaGlasses.streamingState != .stopped else {
+            return
+        }
+        stopMetaGlassesStreaming()
+    }
+
+    func connectMetaGlasses() {
+        metaGlassesDevice.connectGlasses()
+    }
+
+    func disconnectMetaGlasses() {
+        metaGlassesDevice.disconnectGlasses()
+        media.removeBufferedVideo(cameraId: metaGlassesCameraId)
+    }
+
+    func handleMetaGlassesUrl(_ url: URL) {
+        Task {
+            do {
+                try await metaGlassesDevice.handleUrl(url)
+            } catch {
+                makeErrorToast(
+                    title: String(localized: "Meta glasses"),
+                    subTitle: error.localizedDescription
+                )
+            }
+        }
+    }
+
+    // MARK: - MetaGlassesDeviceDelegate
+
+    func metaGlassesDeviceConnected() {
+        DispatchQueue.main.async {
+            self.makeToast(title: String(localized: "Meta glasses connected"))
+        }
+    }
+
+    func metaGlassesDeviceDisconnected() {
+        DispatchQueue.main.async {
+            self.makeToast(title: String(localized: "Meta glasses disconnected"))
+        }
+    }
+
+    func metaGlassesDeviceVideoBuffer(_ sampleBuffer: CMSampleBuffer) {
+        media.appendBufferedVideoSampleBuffer(cameraId: metaGlassesCameraId, sampleBuffer: sampleBuffer)
+    }
+
+    func metaGlassesDeviceRegistrationStateChanged(_ state: MetaGlassesRegistrationState) {
+        DispatchQueue.main.async {
+            self.metaGlasses.registrationState = state
+        }
+    }
+
+    func metaGlassesDeviceStreamingStateChanged(_ state: MetaGlassesStreamingState) {
+        DispatchQueue.main.async {
+            self.metaGlasses.streamingState = state
+        }
+    }
+
+    func metaGlassesDeviceError(_ message: String) {
+        DispatchQueue.main.async {
+            self.makeErrorToast(title: String(localized: "Meta glasses"), subTitle: message)
+        }
+    }
+}

--- a/Moblin/Various/Model/ModelScene.swift
+++ b/Moblin/Various/Model/ModelScene.swift
@@ -241,6 +241,9 @@ extension Model {
     func attachSingleLayout(scene: SettingsScene) {
         streamOverlay.isFrontCameraSelected = false
         deactivateAllMediaPlayers()
+        if scene.videoSource.cameraPosition != .metaGlasses {
+            stopMetaGlassesStreamingIfActive()
+        }
         switch scene.videoSource.cameraPosition {
         case .back:
             attachCamera(scene: scene, position: .back)
@@ -264,6 +267,11 @@ extension Model {
             attachExternalCamera(scene: scene)
         case .screenCapture:
             attachBufferedCamera(cameraId: screenCaptureCameraId, scene: scene)
+        case .metaGlasses:
+            attachBufferedCamera(cameraId: metaGlassesCameraId, scene: scene)
+            if database.metaGlasses.autoStartStopStreaming {
+                startMetaGlassesStreamingIfRegistered()
+            }
         case .backTripleLowEnergy:
             attachBackTripleLowEnergyCamera()
         case .backDualLowEnergy:
@@ -313,7 +321,17 @@ extension Model {
     }
 
     func getFillFrame(scene: SettingsScene) -> Bool {
+        if scene.videoSource.cameraPosition == .metaGlasses {
+            return database.metaGlasses.fillFrame
+        }
         return scene.fillFrame
+    }
+
+    func getVideoSourceRotation(scene: SettingsScene) -> Double {
+        if scene.videoSource.cameraPosition == .metaGlasses {
+            return scene.videoSourceRotation + 90
+        }
+        return scene.videoSourceRotation
     }
 
     func widgetsInCurrentScene(onlyEnabled: Bool) -> [WidgetInScene] {
@@ -897,7 +915,7 @@ extension Model {
             effects.append(drawOnStreamEffect)
         }
         effects += registerGlobalVideoEffectsOnTop()
-        media.setPendingAfterAttachEffects(effects: effects, rotation: scene.videoSourceRotation)
+        media.setPendingAfterAttachEffects(effects: effects, rotation: getVideoSourceRotation(scene: scene))
         for effect in browserEffects.values where !effects.contains(effect) {
             effect.setSceneWidget(sceneWidget: nil, crops: [])
         }

--- a/Moblin/Various/Settings/Settings.swift
+++ b/Moblin/Various/Settings/Settings.swift
@@ -19,6 +19,7 @@ enum SettingsCameraId {
     case mediaPlayer(id: UUID)
     case external(id: String, name: String)
     case screenCapture
+    case metaGlasses
     case none
     case backTripleLowEnergy
     case backDualLowEnergy
@@ -1144,6 +1145,7 @@ class Database: Codable, ObservableObject {
     var remoteSceneId: UUID?
     @Published var sceneNumericInput: Bool = false
     var goPro: SettingsGoPro = .init()
+    var metaGlasses: SettingsMetaGlasses = .init()
     var replay: SettingsReplay = .init()
     var portraitVideoOffsetFromTop: Double = 0.0
     var autoSceneSwitchers: SettingsAutoSceneSwitchers = .init()
@@ -1249,6 +1251,7 @@ class Database: Codable, ObservableObject {
              remoteSceneId,
              sceneNumericInput,
              goPro,
+             metaGlasses,
              replay,
              portraitVideoOffsetFromTop,
              autoSceneSwitchers,
@@ -1325,6 +1328,7 @@ class Database: Codable, ObservableObject {
         try container.encode(.remoteSceneId, remoteSceneId)
         try container.encode(.sceneNumericInput, sceneNumericInput)
         try container.encode(.goPro, goPro)
+        try container.encode(.metaGlasses, metaGlasses)
         try container.encode(.replay, replay)
         try container.encode(.portraitVideoOffsetFromTop, portraitVideoOffsetFromTop)
         try container.encode(.autoSceneSwitchers, autoSceneSwitchers)
@@ -1447,6 +1451,7 @@ class Database: Codable, ObservableObject {
         remoteSceneId = try? container.decode(UUID?.self, forKey: .remoteSceneId)
         sceneNumericInput = container.decode(.sceneNumericInput, Bool.self, false)
         goPro = container.decode(.goPro, SettingsGoPro.self, .init())
+        metaGlasses = container.decode(.metaGlasses, SettingsMetaGlasses.self, .init())
         replay = container.decode(.replay, SettingsReplay.self, .init())
         portraitVideoOffsetFromTop = container.decode(.portraitVideoOffsetFromTop, Double.self, 0.0)
         autoSceneSwitchers = container.decode(.autoSceneSwitchers, SettingsAutoSceneSwitchers.self, .init())
@@ -1819,6 +1824,11 @@ private func addMissingQuickButtonsPageThree(database: Database) {
                                  type: .goPro,
                                  imageOn: "appletvremote.gen1.fill",
                                  imageOff: "appletvremote.gen1",
+                                 page: page)
+    updateQuickButton(database: database, button: button)
+    button = SettingsQuickButton(name: String(localized: "Meta glasses"),
+                                 type: .metaGlasses,
+                                 imageOn: "eyeglasses",
                                  page: page)
     updateQuickButton(database: database, button: button)
     button = SettingsQuickButton(name: String(localized: "Interactive chat"),

--- a/Moblin/Various/Settings/SettingsMetaGlasses.swift
+++ b/Moblin/Various/Settings/SettingsMetaGlasses.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+enum SettingsMetaGlassesResolution: String, Codable, CaseIterable {
+    case low = "Low"
+    case medium = "Medium"
+    case high = "High"
+
+    func toString() -> String {
+        return rawValue
+    }
+}
+
+class SettingsMetaGlasses: Codable, ObservableObject {
+    @Published var enabled: Bool = false
+    @Published var autoStartStopStreaming: Bool = true
+    @Published var fillFrame: Bool = false
+    @Published var resolution: SettingsMetaGlassesResolution = .medium
+    @Published var frameRate: Int = 30
+
+    init() {}
+
+    enum CodingKeys: CodingKey {
+        case enabled,
+             autoStartStopStreaming,
+             fillFrame,
+             resolution,
+             frameRate
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(.enabled, enabled)
+        try container.encode(.autoStartStopStreaming, autoStartStopStreaming)
+        try container.encode(.fillFrame, fillFrame)
+        try container.encode(.resolution, resolution)
+        try container.encode(.frameRate, frameRate)
+    }
+
+    required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        enabled = container.decode(.enabled, Bool.self, false)
+        autoStartStopStreaming = container.decode(.autoStartStopStreaming, Bool.self, true)
+        fillFrame = container.decode(.fillFrame, Bool.self, false)
+        resolution = container.decode(.resolution, SettingsMetaGlassesResolution.self, .medium)
+        frameRate = container.decode(.frameRate, Int.self, 30)
+    }
+}

--- a/Moblin/Various/Settings/SettingsMetaGlasses.swift
+++ b/Moblin/Various/Settings/SettingsMetaGlasses.swift
@@ -6,7 +6,14 @@ enum SettingsMetaGlassesResolution: String, Codable, CaseIterable {
     case high = "High"
 
     func toString() -> String {
-        return rawValue
+        switch self {
+        case .low:
+            return String(localized: "Low")
+        case .medium:
+            return String(localized: "Medium")
+        case .high:
+            return String(localized: "High")
+        }
     }
 }
 

--- a/Moblin/Various/Settings/SettingsQuickButtons.swift
+++ b/Moblin/Various/Settings/SettingsQuickButtons.swift
@@ -45,6 +45,7 @@ enum SettingsQuickButtonType: String, Codable, CaseIterable {
     case djiDevices = "DJI devices"
     case portrait = "Portrait"
     case goPro = "GoPro"
+    case metaGlasses = "Meta glasses"
     case replay = "Replay"
     case connectionPriorities = "Connection priorities"
     case instantReplay = "Instant replay"

--- a/Moblin/Various/Settings/SettingsScene.swift
+++ b/Moblin/Various/Settings/SettingsScene.swift
@@ -2309,6 +2309,7 @@ enum SettingsSceneCameraPosition: String, Codable, CaseIterable {
     case whip = "WHIP"
     case mediaPlayer = "Media player"
     case screenCapture = "Screen capture"
+    case metaGlasses = "Meta glasses"
     case backTripleLowEnergy = "Back triple"
     case backDualLowEnergy = "Back dual"
     case backWideDualLowEnergy = "Back wide dual"
@@ -2367,6 +2368,8 @@ struct SettingsVideoSource {
             return .mediaPlayer(id: mediaPlayerCameraId)
         case .screenCapture:
             return .screenCapture
+        case .metaGlasses:
+            return .metaGlasses
         case .backTripleLowEnergy:
             return .backTripleLowEnergy
         case .backDualLowEnergy:
@@ -2410,6 +2413,8 @@ struct SettingsVideoSource {
             externalCameraName = name
         case .screenCapture:
             cameraPosition = .screenCapture
+        case .metaGlasses:
+            cameraPosition = .metaGlasses
         case .backTripleLowEnergy:
             cameraPosition = .backTripleLowEnergy
         case .backDualLowEnergy:

--- a/Moblin/View/ControlBar/QuickButton/QuickButtonMetaGlassesView.swift
+++ b/Moblin/View/ControlBar/QuickButton/QuickButtonMetaGlassesView.swift
@@ -10,13 +10,13 @@ struct QuickButtonMetaGlassesView: View {
                 HStack {
                     Text("Registration")
                     Spacer()
-                    Text(metaGlasses.registrationState.rawValue)
+                    Text(metaGlasses.registrationState.toString())
                         .foregroundColor(.secondary)
                 }
                 HStack {
                     Text("Streaming")
                     Spacer()
-                    Text(metaGlasses.streamingState.rawValue)
+                    Text(metaGlasses.streamingState.toString())
                         .foregroundColor(.secondary)
                 }
             } header: {

--- a/Moblin/View/ControlBar/QuickButton/QuickButtonMetaGlassesView.swift
+++ b/Moblin/View/ControlBar/QuickButton/QuickButtonMetaGlassesView.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+struct QuickButtonMetaGlassesView: View {
+    @EnvironmentObject var model: Model
+    @ObservedObject var metaGlasses: MetaGlassesState
+
+    var body: some View {
+        Form {
+            Section {
+                HStack {
+                    Text("Registration")
+                    Spacer()
+                    Text(metaGlasses.registrationState.rawValue)
+                        .foregroundColor(.secondary)
+                }
+                HStack {
+                    Text("Streaming")
+                    Spacer()
+                    Text(metaGlasses.streamingState.rawValue)
+                        .foregroundColor(.secondary)
+                }
+            } header: {
+                Text("Status")
+            }
+            if metaGlasses.registrationState == .registered {
+                Section {
+                    if metaGlasses.streamingState == .stopped {
+                        Button("Start streaming") {
+                            model.startMetaGlassesStreaming()
+                        }
+                    } else {
+                        Button("Stop streaming", role: .destructive) {
+                            model.stopMetaGlassesStreaming()
+                        }
+                    }
+                }
+            } else if metaGlasses.registrationState == .unregistered {
+                Section {
+                    Button("Connect glasses") {
+                        model.connectMetaGlasses()
+                    }
+                } footer: {
+                    Text("You will be redirected to the Meta AI app to confirm the connection.")
+                }
+            }
+            ShortcutSectionView {
+                NavigationLink {
+                    MetaGlassesSettingsView(metaGlasses: model.metaGlasses)
+                } label: {
+                    Label("Meta glasses", systemImage: "eyeglasses")
+                }
+            }
+        }
+        .navigationTitle("Meta glasses")
+    }
+}

--- a/Moblin/View/ControlBar/QuickButtonsView.swift
+++ b/Moblin/View/ControlBar/QuickButtonsView.swift
@@ -346,6 +346,10 @@ struct QuickButtonsInnerView: View {
         model.toggleShowingPanel(type: .goPro, panel: .goPro)
     }
 
+    private func metaGlassesAction() {
+        model.toggleShowingPanel(type: .metaGlasses, panel: .metaGlasses)
+    }
+
     private func replayAction(state: ButtonState) {
         model.streamOverlay.showingReplay.toggle()
         state.button.isOn.toggle()
@@ -790,6 +794,17 @@ struct QuickButtonsInnerView: View {
                                 goProAction()
                             }
                             ButtonTextOverlayView(text: String(localized: "GoPro"))
+                        }
+                    case .metaGlasses:
+                        ZStack {
+                            QuickButtonImage(model: model,
+                                             quickButtonsSettings: quickButtonsSettings,
+                                             state: state,
+                                             buttonSize: size)
+                            {
+                                metaGlassesAction()
+                            }
+                            ButtonTextOverlayView(text: String(localized: "Meta"))
                         }
                     case .replay:
                         QuickButtonImage(model: model,

--- a/Moblin/View/MainView.swift
+++ b/Moblin/View/MainView.swift
@@ -170,6 +170,10 @@ private struct MenuView: View {
             NavigationStack {
                 QuickButtonGoProView(goProState: model.goPro, goPro: model.database.goPro)
             }
+        case .metaGlasses:
+            NavigationStack {
+                QuickButtonMetaGlassesView(metaGlasses: model.metaGlasses)
+            }
         case .connectionPriorities:
             NavigationStack {
                 StreamSrtConnectionPriorityView(stream: model.stream)

--- a/Moblin/View/Settings/MetaGlasses/MetaGlassesSettingsView.swift
+++ b/Moblin/View/Settings/MetaGlasses/MetaGlassesSettingsView.swift
@@ -1,0 +1,109 @@
+import SwiftUI
+
+struct MetaGlassesSettingsView: View {
+    @EnvironmentObject var model: Model
+    @ObservedObject var metaGlasses: MetaGlassesState
+
+    var body: some View {
+        Form {
+            Section {
+                Toggle("Enabled", isOn: Binding(get: {
+                    model.database.metaGlasses.enabled
+                }, set: { value in
+                    model.database.metaGlasses.enabled = value
+                    model.reloadMetaGlasses()
+                }))
+            }
+            if model.database.metaGlasses.enabled {
+                Section {
+                    HStack {
+                        Text("Status")
+                        Spacer()
+                        Text(metaGlasses.registrationState.rawValue)
+                            .foregroundColor(.secondary)
+                    }
+                    if metaGlasses.registrationState == .unregistered {
+                        Button("Connect glasses") {
+                            model.connectMetaGlasses()
+                        }
+                    } else if metaGlasses.registrationState == .registered {
+                        Button("Disconnect glasses", role: .destructive) {
+                            model.disconnectMetaGlasses()
+                        }
+                    }
+                } header: {
+                    Text("Connection")
+                } footer: {
+                    Text("""
+                    Connect your Meta AI glasses through the Meta AI app. \
+                    Make sure developer mode is enabled in the Meta AI app settings.
+                    """)
+                }
+                Section {
+                    Toggle("Auto start/stop streaming", isOn: Binding(get: {
+                        model.database.metaGlasses.autoStartStopStreaming
+                    }, set: { value in
+                        model.database.metaGlasses.autoStartStopStreaming = value
+                        model.objectWillChange.send()
+                    }))
+                } header: {
+                    Text("Streaming")
+                } footer: {
+                    Text("""
+                    Automatically start streaming from the glasses when switching \
+                    to a scene using the Meta glasses camera, and stop when switching away.
+                    """)
+                }
+                Section {
+                    Toggle("Fill frame", isOn: Binding(get: {
+                        model.database.metaGlasses.fillFrame
+                    }, set: { value in
+                        model.database.metaGlasses.fillFrame = value
+                        model.objectWillChange.send()
+                        model.sceneUpdated(attachCamera: true, updateRemoteScene: false)
+                    }))
+                } header: {
+                    Text("Display")
+                } footer: {
+                    Text("""
+                    Fill the entire screen with the glasses video, cropping \
+                    edges. When off, the full image is shown centered with \
+                    black bars.
+                    """)
+                }
+                Section {
+                    Picker("Resolution", selection: Binding(get: {
+                        model.database.metaGlasses.resolution
+                    }, set: { (value: SettingsMetaGlassesResolution) in
+                        guard value != model.database.metaGlasses.resolution else { return }
+                        model.database.metaGlasses.resolution = value
+                        model.objectWillChange.send()
+                    })) {
+                        ForEach(SettingsMetaGlassesResolution.allCases, id: \.self) {
+                            Text($0.toString())
+                        }
+                    }
+                    Picker("Frame rate", selection: Binding(get: {
+                        model.database.metaGlasses.frameRate
+                    }, set: { (value: Int) in
+                        guard value != model.database.metaGlasses.frameRate else { return }
+                        model.database.metaGlasses.frameRate = value
+                        model.objectWillChange.send()
+                    })) {
+                        Text("15").tag(15)
+                        Text("24").tag(24)
+                        Text("30").tag(30)
+                    }
+                } header: {
+                    Text("Video")
+                } footer: {
+                    Text("""
+                    Configure the video quality from the glasses camera. Higher \
+                    resolution and frame rate use more battery on the glasses.
+                    """)
+                }
+            }
+        }
+        .navigationTitle("Meta glasses")
+    }
+}

--- a/Moblin/View/Settings/MetaGlasses/MetaGlassesSettingsView.swift
+++ b/Moblin/View/Settings/MetaGlasses/MetaGlassesSettingsView.swift
@@ -19,7 +19,7 @@ struct MetaGlassesSettingsView: View {
                     HStack {
                         Text("Status")
                         Spacer()
-                        Text(metaGlasses.registrationState.rawValue)
+                        Text(metaGlasses.registrationState.toString())
                             .foregroundColor(.secondary)
                     }
                     if metaGlasses.registrationState == .unregistered {
@@ -35,8 +35,7 @@ struct MetaGlassesSettingsView: View {
                     Text("Connection")
                 } footer: {
                     Text("""
-                    Connect your Meta AI glasses through the Meta AI app. \
-                    Make sure developer mode is enabled in the Meta AI app settings.
+                    Connect your Meta AI glasses through the Meta AI app.
                     """)
                 }
                 Section {

--- a/Moblin/View/Settings/SettingsView.swift
+++ b/Moblin/View/Settings/SettingsView.swift
@@ -133,6 +133,11 @@ struct SettingsView: View {
                         Label("GoPro", systemImage: "appletvremote.gen1")
                     }
                     NavigationLink {
+                        MetaGlassesSettingsView(metaGlasses: model.metaGlasses)
+                    } label: {
+                        Label("Meta glasses", systemImage: "eyeglasses")
+                    }
+                    NavigationLink {
                         CatPrintersSettingsView(catPrinters: database.catPrinters)
                     } label: {
                         Label("Cat printers", systemImage: "pawprint")

--- a/README.md
+++ b/README.md
@@ -214,6 +214,10 @@ TestFlight: https://testflight.apple.com/join/PDpxEaGh
 - DJI camera Bluetooth controller.
   - Automatically start DJI camera live stream.
   - Tested with OA4, OA3 and OP3.
+- Meta smart glasses as camera source.
+  - Stream video from Meta glasses directly into scenes.
+  - Auto start/stop streaming when switching scenes.
+  - Configurable resolution and frame rate.
 - GoPro QR-code creator.
 - Show grid for easier positioning.
 - Camera settings (on some cameras).

--- a/User.template.xcconfig
+++ b/User.template.xcconfig
@@ -6,3 +6,9 @@ BASE_PRODUCT_BUNDLE_IDENTIFIER = com.eerimoq.Mobs
 
 // 'free' or 'all'. 'all' requires paying for Apple development account.
 CAPABILITIES = free
+
+// Meta Wearables Application Id from Meta Wearables Developer Center.
+MWDAT_META_APP_ID = 0
+
+// Client token from Meta Wearables Developer Center.
+MWDAT_CLIENT_TOKEN =


### PR DESCRIPTION
## Summary
   
   Adds support for using Meta smart glasses as a camera source in Moblin via the Meta Wearables Device Access Toolkit (MWDAT) SDK.
   
   ## Features
   
   - **Meta Glasses camera source** — Stream video from Meta glasses directly into Moblin scenes by selecting "Meta glasses" as the camera position
   - **Registration flow** — Connect/disconnect glasses through the Meta AI app with status tracking (unregistered → registering → registered)
   - **Streaming control** — Start/stop video streaming from glasses with real-time state updates (stopped/waiting/streaming)
   - **Auto start/stop streaming** — Optionally auto-start streaming when switching to a Meta Glasses scene, and stop when switching away
   - **Fill frame** — Option to crop-and-fill the glasses video to remove black bars (glasses send portrait 720×1280 but content is landscape)
   - **Video rotation correction** — Automatically corrects the landscape content delivered in portrait orientation
   - **Configurable resolution & frame rate** — Low/Medium/High resolution and 15/24/30 fps options
   - **Quick button** — Dedicated quick button for at-a-glance status and streaming control
   - **Settings UI** — Full settings page with connection management, streaming, display, and video quality sections
   
   ## Architecture
   
   | File | Purpose |
   |------|---------|
   | `MetaGlassesDevice.swift` | SDK wrapper handling registration, permissions, streaming sessions, and delegate callbacks |
   | `ModelMetaGlasses.swift` | Model extension bridging the device to Moblin's camera/buffered-audio pipeline |
   | `SettingsMetaGlasses.swift` | Codable settings (enabled, autoStartStopStreaming, fillFrame, resolution, frameRate) |
   | `MetaGlassesSettingsView.swift` | SwiftUI settings view with dynamic status updates |
   | `QuickButtonMetaGlassesView.swift` | Quick button panel for streaming control |
   | `ModelScene.swift` | Scene attachment, fill-frame override, and rotation correction |
   
   ## Setup
   
   ### 1. Create a Meta Wearables application
   
   Before this integration can work, an application must be registered in the [Meta Wearables Developer Center](https://wearables.developer.meta.com). This will provide the **Meta App ID** and **Client Token** required by the MWDAT 
  SDK.
   
   ### 2. Configure credentials
   
   Set the credentials from the Developer Center in `Config/User.xcconfig` (see `User.template.xcconfig` for the template):
   
   ```
   MWDAT_META_APP_ID = <your_app_id>
   MWDAT_CLIENT_TOKEN = <your_client_token>
   ```
   
   These are injected into `Info.plist` at build time via `$(MWDAT_META_APP_ID)` and `$(MWDAT_CLIENT_TOKEN)`.