### PR TITLE
Add chat bot zoom command

### DIFF
--- a/Moblin/Various/Model/ModelChatBot.swift
+++ b/Moblin/Various/Model/ModelChatBot.swift
@@ -88,6 +88,27 @@ private func getAnswer(_ language: String) -> String {
     return answerByLanguage[language] ?? ""
 }
 
+enum ChatBotResponseText {
+    static func zoomValueMustBeNumber() -> String {
+        return String(localized: "Sorry, zoom value must be a number.")
+    }
+
+    static func zoomUnavailable() -> String {
+        return String(localized: "Sorry, zoom is not available for the current camera.")
+    }
+
+    static func zoomUnavailable(value: Float, minX: Float, maxX: Float) -> String {
+        return String(
+            format: String(
+                localized: "Sorry, zoom %@x is not available for the current camera. Available range is %@x to %@x."
+            ),
+            formatOneDecimal(value),
+            formatOneDecimal(minX),
+            formatOneDecimal(maxX)
+        )
+    }
+}
+
 extension Model {
     func executeChatBotMessage() {
         guard let message = chatBotMessages.popFirst() else {
@@ -127,6 +148,8 @@ extension Model {
                 handleChatBotMessageFax(command: command)
             case "filter":
                 handleChatBotMessageFilter(command: command)
+            case "zoom":
+                handleChatBotMessageZoom(command: command)
             case "say":
                 handleChatBotMessageTtsSay(command: command)
             case "tesla":
@@ -636,6 +659,64 @@ extension Model {
                 break
             }
         }
+    }
+
+    private func handleChatBotMessageZoom(command: ChatBotCommand) {
+        let permissions = database.chat.botCommandPermissions.zoom
+        executeIfUserAllowedToUseChatBot(
+            permissions: permissions,
+            command: command
+        ) {
+            let value = command.rest()
+            guard !value.isEmpty, var x = Float(value) else {
+                self.sendChatBotZoomErrorIfEnabled(
+                    permissions: permissions,
+                    command: command,
+                    message: ChatBotResponseText.zoomValueMustBeNumber()
+                )
+                return
+            }
+            guard self.zoom.hasZoom else {
+                self.sendChatBotZoomErrorIfEnabled(
+                    permissions: permissions,
+                    command: command,
+                    message: ChatBotResponseText.zoomUnavailable()
+                )
+                return
+            }
+            let minX = self.cameraZoomXMinimum
+            let maxX = self.cameraZoomXMaximum
+            if x == 0 {
+                x = minX
+            }
+            guard x >= minX, x <= maxX else {
+                self.sendChatBotZoomErrorIfEnabled(
+                    permissions: permissions,
+                    command: command,
+                    message: ChatBotResponseText.zoomUnavailable(value: x, minX: minX, maxX: maxX)
+                )
+                return
+            }
+            guard self.setChatBotZoomX(x: x, rate: self.database.zoom.speed) != nil else {
+                self.sendChatBotZoomErrorIfEnabled(
+                    permissions: permissions,
+                    command: command,
+                    message: ChatBotResponseText.zoomUnavailable()
+                )
+                return
+            }
+        }
+    }
+
+    private func sendChatBotZoomErrorIfEnabled(
+        permissions: SettingsChatBotPermissionsCommand,
+        command: ChatBotCommand,
+        message: String
+    ) {
+        guard permissions.sendChatMessages else {
+            return
+        }
+        sendChatBotReply(message: message, platform: command.message.platform)
     }
 
     private func handleChatBotMessageTesla(command: ChatBotCommand) {

--- a/Moblin/Various/Model/ModelZoom.swift
+++ b/Moblin/Various/Model/ModelZoom.swift
@@ -33,16 +33,7 @@ extension Model {
             }
             if setCameraZoomX(x: preset.x, rate: database.zoom.speed) != nil {
                 setZoomXWhenInRange(x: preset.x)
-                switch getSelectedScene()?.videoSource.cameraPosition {
-                case .backTripleLowEnergy:
-                    attachBackTripleLowEnergyCamera(force: false)
-                case .backDualLowEnergy:
-                    attachBackDualLowEnergyCamera(force: false)
-                case .backWideDualLowEnergy:
-                    attachBackWideDualLowEnergyCamera(force: false)
-                default:
-                    break
-                }
+                updateLowEnergyCameraAfterZoomChange()
             }
         } else {
             clearZoomPresetId()
@@ -54,6 +45,16 @@ extension Model {
         if let x = setCameraZoomX(x: x, rate: rate) {
             setZoomXWhenInRange(x: x, setPinch: setPinch)
         }
+    }
+
+    func setChatBotZoomX(x: Float, rate: Float? = nil) -> Float? {
+        clearZoomPresetId()
+        guard let x = setCameraZoomX(x: x, rate: rate) else {
+            return nil
+        }
+        setZoomXWhenInRange(x: x)
+        updateLowEnergyCameraAfterZoomChange()
+        return x
     }
 
     func setZoomXWhenInRange(x: Float, setPinch: Bool = true) {
@@ -238,6 +239,19 @@ extension Model {
     private func showPreset(preset: SettingsZoomPreset) -> Bool {
         let x = preset.x
         return x >= cameraZoomXMinimum && x <= cameraZoomXMaximum
+    }
+
+    func updateLowEnergyCameraAfterZoomChange() {
+        switch getSelectedScene()?.videoSource.cameraPosition {
+        case .backTripleLowEnergy:
+            attachBackTripleLowEnergyCamera(force: false)
+        case .backDualLowEnergy:
+            attachBackDualLowEnergyCamera(force: false)
+        case .backWideDualLowEnergy:
+            attachBackWideDualLowEnergyCamera(force: false)
+        default:
+            break
+        }
     }
 
     func setCameraZoomX(x: Float, rate: Float? = nil) -> Float? {

--- a/Moblin/Various/Settings/SettingsChat.swift
+++ b/Moblin/Various/Settings/SettingsChat.swift
@@ -150,6 +150,7 @@ class SettingsChatBotPermissions: Codable {
     var fax: SettingsChatBotPermissionsCommand = .init()
     var snapshot: SettingsChatBotPermissionsCommand = .init()
     var filter: SettingsChatBotPermissionsCommand = .init()
+    var zoom: SettingsChatBotPermissionsCommand = .init()
     var tesla: SettingsChatBotPermissionsCommand = .init()
     var audio: SettingsChatBotPermissionsCommand = .init()
     var reaction: SettingsChatBotPermissionsCommand = .init()
@@ -169,6 +170,7 @@ class SettingsChatBotPermissions: Codable {
              fax,
              snapshot,
              filter,
+             zoom,
              tesla,
              audio,
              reaction,
@@ -190,6 +192,7 @@ class SettingsChatBotPermissions: Codable {
         try container.encode(.fax, fax)
         try container.encode(.snapshot, snapshot)
         try container.encode(.filter, filter)
+        try container.encode(.zoom, zoom)
         try container.encode(.tesla, tesla)
         try container.encode(.audio, audio)
         try container.encode(.reaction, reaction)
@@ -213,6 +216,7 @@ class SettingsChatBotPermissions: Codable {
         fax = container.decode(.fax, SettingsChatBotPermissionsCommand.self, .init())
         snapshot = container.decode(.snapshot, SettingsChatBotPermissionsCommand.self, .init())
         filter = container.decode(.filter, SettingsChatBotPermissionsCommand.self, .init())
+        zoom = container.decode(.zoom, SettingsChatBotPermissionsCommand.self, .init())
         tesla = container.decode(.tesla, SettingsChatBotPermissionsCommand.self, .init())
         audio = container.decode(.audio, SettingsChatBotPermissionsCommand.self, .init())
         reaction = container.decode(.reaction, SettingsChatBotPermissionsCommand.self, .init())

--- a/Moblin/View/Settings/Chat/ChatBotSettingsView.swift
+++ b/Moblin/View/Settings/Chat/ChatBotSettingsView.swift
@@ -172,7 +172,10 @@ private struct ZoomPermissionsSettingsView: View {
                 Text("")
                 Text("0 means the lowest available zoom for the current camera.")
                 Text("")
-                Text("If the value is unavailable for the current camera, the command is ignored unless chat responses are enabled.")
+                Text("""
+                If the value is unavailable for the current camera, the command \
+                is ignored unless chat responses are enabled.
+                """)
             }
         }
     }

--- a/Moblin/View/Settings/Chat/ChatBotSettingsView.swift
+++ b/Moblin/View/Settings/Chat/ChatBotSettingsView.swift
@@ -155,6 +155,29 @@ private struct FilterPermissionsSettingsView: View {
     }
 }
 
+private struct ZoomPermissionsSettingsView: View {
+    let permissions: SettingsChatBotPermissionsCommand
+
+    var body: some View {
+        Section {
+            PermissionsSettingsView(
+                title: "!moblin zoom <value>",
+                permissions: permissions
+            )
+        } footer: {
+            VStack(alignment: .leading) {
+                Text("Set zoom for the current camera.")
+                Text("")
+                Text("Examples: !moblin zoom 0, !moblin zoom 1 and !moblin zoom 8.")
+                Text("")
+                Text("0 means the lowest available zoom for the current camera.")
+                Text("")
+                Text("If the value is unavailable for the current camera, the command is ignored unless chat responses are enabled.")
+            }
+        }
+    }
+}
+
 private struct ScenePermissionsSettingsView: View {
     let permissions: SettingsChatBotPermissionsCommand
 
@@ -396,6 +419,7 @@ private struct ChatBotCommandsSettingsView: View {
             TtsSayPermissionsSettingsView(permissions: permissions.tts)
             WidgetPermissionsSettingsView(permissions: permissions.widget)
             TwitchPermissionsSettingsView(permissions: permissions.twitch)
+            ZoomPermissionsSettingsView(permissions: permissions.zoom)
         }
         .navigationTitle("Commands")
     }

--- a/MoblinTests/ChatBotCommandSuite.swift
+++ b/MoblinTests/ChatBotCommandSuite.swift
@@ -54,6 +54,16 @@ struct ChatBotCommandSuite {
         #expect(command.rest() == "")
     }
 
+    @Test
+    func zoomCommand() throws {
+        let message = createMessage(text: "!moblin zoom 0.5")
+        let command = try #require(ChatBotCommand(message: message, aliases: []))
+        #expect(command.popFirst() == "zoom")
+        #expect(command.rest() == "0.5")
+        #expect(command.popFirst() == "0.5")
+        #expect(command.popFirst() == nil)
+    }
+
     private func createMessage(text: String) -> ChatBotMessage {
         return ChatBotMessage(platform: .twitch,
                               user: "erik",

--- a/docs/chat-bot-help.md
+++ b/docs/chat-bot-help.md
@@ -11,6 +11,7 @@
 | !moblin tts on | Turn on chat text to speech. |
 | !moblin tts off | Turn off chat text to speech. |
 | !moblin say \<message> | Say given message. |
+| !moblin zoom \<value> | Set zoom for the current camera. `0` means the lowest available zoom. |
 | !moblin scene \<name> | Change scene. |
 | !moblin stream title \<title> | Set stream title. |
 | !moblin widget \<name> timer \<number> add \<seconds> | Add time to a timer. |


### PR DESCRIPTION
Added a new !moblin zoom <value> command the bot can now control the camera zoom.  It rejects any unsupported zoom levels, sets 0 to the smallest available zoom, keeps the low-energy lens-switching thing happy, and doesn't break any existing zoom controls in the app. 