### PR TITLE
Add configurable instant replay delay

### DIFF
--- a/Moblin/Various/Model/ModelReplay.swift
+++ b/Moblin/Various/Model/ModelReplay.swift
@@ -20,7 +20,7 @@ extension Model {
             return false
         }
         replay.isSaving = true
-        DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(delay ?? 5)) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(delay ?? stream.replay.instantReplayDelay)) {
             self.replayBuffer.createFile { file in
                 DispatchQueue.main.async {
                     self.replay.isSaving = false
@@ -67,7 +67,9 @@ extension Model {
         guard replay.instantReplayCountdown == 0 else {
             return
         }
-        let savingStarted = saveReplay(start: start, delay: delay) { video in
+        let actualDelay = delay ??  stream.replay.instantReplayDelay
+        
+        let savingStarted = saveReplay(start: start, delay: actualDelay) { video in
             self.loadReplay(video: video) {
                 self.replay.isPlaying = true
                 if !self.replayPlay() {
@@ -76,7 +78,7 @@ extension Model {
             }
         }
         if savingStarted {
-            replay.instantReplayCountdown = delay ?? 6
+            replay.instantReplayCountdown = actualDelay + 1;
             instantReplayCountdownTick()
         }
     }
@@ -170,7 +172,11 @@ extension Model {
         replayEffect?.cancel()
         replayEffect = nil
     }
-
+    
+    func replayDelay(delay: Int) {
+        stream.replay.instantReplayDelay = delay
+    }
+    
     func streamReplayEnabledUpdated() {
         replayBuffer = ReplayBuffer()
         media.setReplayBuffering(enabled: stream.replay.enabled)

--- a/Moblin/Various/Model/ModelReplay.swift
+++ b/Moblin/Various/Model/ModelReplay.swift
@@ -20,23 +20,24 @@ extension Model {
             return false
         }
         replay.isSaving = true
-        DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(delay ?? stream.replay.instantReplayDelay)) {
-            self.replayBuffer.createFile { file in
-                DispatchQueue.main.async {
-                    self.replay.isSaving = false
-                    guard let file else {
-                        return
+        DispatchQueue.main
+            .asyncAfter(deadline: .now() + .seconds(delay ?? stream.replay.postTriggerDuration)) {
+                self.replayBuffer.createFile { file in
+                    DispatchQueue.main.async {
+                        self.replay.isSaving = false
+                        guard let file else {
+                            return
+                        }
+                        let replaySettings = self.replaysStorage.createReplay()
+                        replaySettings.start = start ?? self.database.replay.start
+                        replaySettings.stop = self.database.replay.stop
+                        replaySettings.duration = file.duration
+                        try? FileManager.default.copyItem(at: file.url, to: replaySettings.url())
+                        self.replaysStorage.append(replay: replaySettings)
+                        completion?(replaySettings)
                     }
-                    let replaySettings = self.replaysStorage.createReplay()
-                    replaySettings.start = start ?? self.database.replay.start
-                    replaySettings.stop = self.database.replay.stop
-                    replaySettings.duration = file.duration
-                    try? FileManager.default.copyItem(at: file.url, to: replaySettings.url())
-                    self.replaysStorage.append(replay: replaySettings)
-                    completion?(replaySettings)
                 }
             }
-        }
         return true
     }
 
@@ -67,8 +68,8 @@ extension Model {
         guard replay.instantReplayCountdown == 0 else {
             return
         }
-        let actualDelay = delay ??  stream.replay.instantReplayDelay
-        
+        let actualDelay = delay ?? stream.replay.postTriggerDuration
+
         let savingStarted = saveReplay(start: start, delay: actualDelay) { video in
             self.loadReplay(video: video) {
                 self.replay.isPlaying = true
@@ -78,7 +79,7 @@ extension Model {
             }
         }
         if savingStarted {
-            replay.instantReplayCountdown = actualDelay + 1;
+            replay.instantReplayCountdown = actualDelay + 1
             instantReplayCountdownTick()
         }
     }
@@ -172,11 +173,11 @@ extension Model {
         replayEffect?.cancel()
         replayEffect = nil
     }
-    
+
     func replayDelay(delay: Int) {
-        stream.replay.instantReplayDelay = delay
+        stream.replay.postTriggerDuration = delay
     }
-    
+
     func streamReplayEnabledUpdated() {
         replayBuffer = ReplayBuffer()
         media.setReplayBuffering(enabled: stream.replay.enabled)

--- a/Moblin/Various/Model/ModelReplay.swift
+++ b/Moblin/Various/Model/ModelReplay.swift
@@ -69,7 +69,6 @@ extension Model {
             return
         }
         let actualDelay = delay ?? stream.replay.postTriggerDuration
-
         let savingStarted = saveReplay(start: start, delay: actualDelay) { video in
             self.loadReplay(video: video) {
                 self.replay.isPlaying = true
@@ -172,10 +171,6 @@ extension Model {
     func replayCancel() {
         replayEffect?.cancel()
         replayEffect = nil
-    }
-
-    func replayDelay(delay: Int) {
-        stream.replay.postTriggerDuration = delay
     }
 
     func streamReplayEnabledUpdated() {

--- a/Moblin/Various/Settings/SettingsStream.swift
+++ b/Moblin/Various/Settings/SettingsStream.swift
@@ -763,12 +763,11 @@ struct SettingsStreamReplayStinger: Codable {
 
 class SettingsStreamReplay: Codable, ObservableObject {
     @Published var enabled: Bool = false
-    @Published var instantReplayDelay: Int = 5
+    @Published var postTriggerDuration: Int = 2
     @Published var transitionType: SettingsStreamReplayTransitionType = .fade
     @Published var inStinger: SettingsStreamReplayStinger = .init()
     @Published var outStinger: SettingsStreamReplayStinger = .init()
     var enterForegroundCountAtLatestUsage: Int?
-    
 
     init() {}
 
@@ -776,7 +775,7 @@ class SettingsStreamReplay: Codable, ObservableObject {
         case enabled,
              fade,
              transitionType,
-             instantReplayDelay,
+             postTriggerDuration,
              inStinger,
              outStinger,
              enterForegroundCountAtLatestUsage
@@ -786,7 +785,7 @@ class SettingsStreamReplay: Codable, ObservableObject {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(.enabled, enabled)
         try container.encode(.transitionType, transitionType)
-        try container.encode(.instantReplayDelay, instantReplayDelay)
+        try container.encode(.postTriggerDuration, postTriggerDuration)
         try container.encode(.inStinger, inStinger)
         try container.encode(.outStinger, outStinger)
         try container.encode(.enterForegroundCountAtLatestUsage, enterForegroundCountAtLatestUsage)
@@ -795,7 +794,7 @@ class SettingsStreamReplay: Codable, ObservableObject {
     required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         enabled = container.decode(.enabled, Bool.self, false)
-        instantReplayDelay = container.decode(.instantReplayDelay, Int.self, 5)
+        postTriggerDuration = container.decode(.postTriggerDuration, Int.self, 2)
         if let fade = try? container.decode(Bool.self, forKey: .fade) {
             if fade {
                 transitionType = .fade
@@ -815,7 +814,7 @@ class SettingsStreamReplay: Codable, ObservableObject {
     func clone() -> SettingsStreamReplay {
         let new = SettingsStreamReplay()
         new.enabled = enabled
-        new.instantReplayDelay = instantReplayDelay
+        new.postTriggerDuration = postTriggerDuration
         new.transitionType = transitionType
         new.inStinger = inStinger
         new.outStinger = outStinger

--- a/Moblin/Various/Settings/SettingsStream.swift
+++ b/Moblin/Various/Settings/SettingsStream.swift
@@ -763,10 +763,12 @@ struct SettingsStreamReplayStinger: Codable {
 
 class SettingsStreamReplay: Codable, ObservableObject {
     @Published var enabled: Bool = false
+    @Published var instantReplayDelay: Int = 5
     @Published var transitionType: SettingsStreamReplayTransitionType = .fade
     @Published var inStinger: SettingsStreamReplayStinger = .init()
     @Published var outStinger: SettingsStreamReplayStinger = .init()
     var enterForegroundCountAtLatestUsage: Int?
+    
 
     init() {}
 
@@ -774,6 +776,7 @@ class SettingsStreamReplay: Codable, ObservableObject {
         case enabled,
              fade,
              transitionType,
+             instantReplayDelay,
              inStinger,
              outStinger,
              enterForegroundCountAtLatestUsage
@@ -783,6 +786,7 @@ class SettingsStreamReplay: Codable, ObservableObject {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(.enabled, enabled)
         try container.encode(.transitionType, transitionType)
+        try container.encode(.instantReplayDelay, instantReplayDelay)
         try container.encode(.inStinger, inStinger)
         try container.encode(.outStinger, outStinger)
         try container.encode(.enterForegroundCountAtLatestUsage, enterForegroundCountAtLatestUsage)
@@ -791,6 +795,7 @@ class SettingsStreamReplay: Codable, ObservableObject {
     required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         enabled = container.decode(.enabled, Bool.self, false)
+        instantReplayDelay = container.decode(.instantReplayDelay, Int.self, 5)
         if let fade = try? container.decode(Bool.self, forKey: .fade) {
             if fade {
                 transitionType = .fade
@@ -810,6 +815,7 @@ class SettingsStreamReplay: Codable, ObservableObject {
     func clone() -> SettingsStreamReplay {
         let new = SettingsStreamReplay()
         new.enabled = enabled
+        new.instantReplayDelay = instantReplayDelay
         new.transitionType = transitionType
         new.inStinger = inStinger
         new.outStinger = outStinger

--- a/Moblin/View/Settings/Streams/Stream/Replay/StreamReplaySettingsView.swift
+++ b/Moblin/View/Settings/Streams/Stream/Replay/StreamReplaySettingsView.swift
@@ -106,6 +106,14 @@ struct StreamReplaySettingsView: View {
     let stream: SettingsStream
     @ObservedObject var replay: SettingsStreamReplay
 
+    private func submitInstantReplayDelay(value: Float) {
+        model.replayDelay(delay: Int(value))
+    }
+
+    private func formatInstantReplayDelay(value: Float) -> String {
+        return String(Int(value)) + " s"
+    }
+
     var body: some View {
         Form {
             Section {
@@ -137,23 +145,19 @@ struct StreamReplaySettingsView: View {
                 case .none:
                     EmptyView()
                 }
-                NavigationLink {
-                    TextEditView(
-                        title: String(localized: "Instant replay delay"),
-                        value: String($replay.instantReplayDelay.wrappedValue),
-                        footers: [
-                            String(
-                                localized: "Seconds to record after the Instant replay button is pressed"
-                            ),
-                        ],
-                        keyboardType: .numbersAndPunctuation
-                    ) {
-                       model.replayDelay(delay: Int($0) ?? 5)
-                    }
-                } label: {
-                    TextItemView(name: "Instant replay delay", value: "\(String($replay.instantReplayDelay.wrappedValue)) s")
+                Section {
+                    SliderView(value: Float($replay.postTriggerDuration.wrappedValue),
+                               minimum: 0,
+                               maximum: 5,
+                               step: 1,
+                               onSubmit: submitInstantReplayDelay,
+                               width: 70,
+                               format: formatInstantReplayDelay)
+                } header: {
+                    Text("Instant replay delay")
+                } footer: {
+                    Text("Seconds to record after the Instant replay button is pressed")
                 }
-                
             }
         }
         .navigationTitle("Replay")

--- a/Moblin/View/Settings/Streams/Stream/Replay/StreamReplaySettingsView.swift
+++ b/Moblin/View/Settings/Streams/Stream/Replay/StreamReplaySettingsView.swift
@@ -137,6 +137,23 @@ struct StreamReplaySettingsView: View {
                 case .none:
                     EmptyView()
                 }
+                NavigationLink {
+                    TextEditView(
+                        title: String(localized: "Instant replay delay"),
+                        value: String($replay.instantReplayDelay.wrappedValue),
+                        footers: [
+                            String(
+                                localized: "Seconds to record after the Instant replay button is pressed"
+                            ),
+                        ],
+                        keyboardType: .numbersAndPunctuation
+                    ) {
+                       model.replayDelay(delay: Int($0) ?? 5)
+                    }
+                } label: {
+                    TextItemView(name: "Instant replay delay", value: "\(String($replay.instantReplayDelay.wrappedValue)) s")
+                }
+                
             }
         }
         .navigationTitle("Replay")

--- a/Moblin/View/Settings/Streams/Stream/Replay/StreamReplaySettingsView.swift
+++ b/Moblin/View/Settings/Streams/Stream/Replay/StreamReplaySettingsView.swift
@@ -107,11 +107,11 @@ struct StreamReplaySettingsView: View {
     @ObservedObject var replay: SettingsStreamReplay
 
     private func submitInstantReplayDelay(value: Float) {
-        model.replayDelay(delay: Int(value))
+        model.stream.replay.postTriggerDuration = Int(value)
     }
 
     private func formatInstantReplayDelay(value: Float) -> String {
-        return String(Int(value)) + " s"
+        return "\(Int(value)) s"
     }
 
     var body: some View {
@@ -154,9 +154,9 @@ struct StreamReplaySettingsView: View {
                                width: 70,
                                format: formatInstantReplayDelay)
                 } header: {
-                    Text("Instant replay delay")
+                    Text("Replay save delay")
                 } footer: {
-                    Text("Seconds to record after the Instant replay button is pressed")
+                    Text("Seconds to record after the Instant replay/Save replay button is pressed")
                 }
             }
         }


### PR DESCRIPTION
This lets a user configure how many seconds to record after the 'Instant Replay' or 'Save Instant Replay' buttons are pressed.  Right now it's hardcoded to 5 seconds, but for my application I want to set it to 1 second (replaying the action that led to a goal for example). 

I am not a swift developer, so I tried to reproduce the patterns I saw in the code, and I tucked the delay in the Replay settings for a stream (defaulting to 5 seconds, i.e. the existing behavior)

I did not translate the strings into various languages (I'm not sure how you usually deal with it), but made them localizable.