### PR TITLE
Hide scoreboard clock when it reaches 0:00

### DIFF
--- a/Moblin/VideoEffects/Scoreboard/ScoreboardEffectModularView.swift
+++ b/Moblin/VideoEffects/Scoreboard/ScoreboardEffectModularView.swift
@@ -156,10 +156,12 @@ struct ScoreboardEffectModularView: View {
                                 .font(.system(size: fontSize() * 0.6))
                                 .minimumScaleFactor(0.1)
                         }
-                        Text(config.global.timer)
-                            .font(.system(size: fontSize() * 0.9))
-                            .monospacedDigit()
-                            .minimumScaleFactor(0.1)
+                        if config.global.timer != "0:00" {
+                            Text(config.global.timer)
+                                .font(.system(size: fontSize() * 0.9))
+                                .monospacedDigit()
+                                .minimumScaleFactor(0.1)
+                        }
                     }
                     .frame(width: fontSize() * 3.5, height: teamRowFullHeight)
                 } else {


### PR DESCRIPTION
In the modular scoreboard, it is impossible to display the period without displaying the clock (I'm using the side by side view with info box).

In games with a shot clock (like water polo or hockey) where the clock doesn't run continuously,  I don't want to display a clock that is not the actual game clock in the field, but knowing which period we are in is still useful (and I can update it with the remote control).

This patch simply hides the clock display when it reaches 0:00, so in sports where you don't want to see the clock but want to see the period, simply set the clock to 0:00 and it will disappear.