### PR TITLE
Toggle clock in modular scoreboard

### DIFF
--- a/Moblin/RemoteControl/RemoteControl.swift
+++ b/Moblin/RemoteControl/RemoteControl.swift
@@ -886,8 +886,12 @@ struct RemoteControlScoreboardMatchConfig: Codable {
         return "\(global.periodLabel) \(global.period)".trim()
     }
 
-    func infoBoxStats() -> [String] {
-        return [global.timer, periodFull(), global.infoBoxText].filter { !$0.isEmpty }
+    func infoBoxStats(showClock: Bool = true) -> [String] {
+        if showClock {
+            return [global.timer, periodFull(), global.infoBoxText].filter { !$0.isEmpty }
+        } else {
+            return [periodFull(), global.infoBoxText].filter { !$0.isEmpty }
+        }
     }
 }
 

--- a/Moblin/RemoteControl/RemoteControl.swift
+++ b/Moblin/RemoteControl/RemoteControl.swift
@@ -860,6 +860,7 @@ struct RemoteControlScoreboardGlobalStats: Codable {
     var showTitle: Bool?
     var showStats: Bool?
     var showMoreStats: Bool?
+    var showClock: Bool?
 
     func minutesAndSeconds() -> (Int, Int) {
         return clockAsMinutesAndSeconds(clock: timer)

--- a/Moblin/RemoteControl/Web/js/remote.mjs
+++ b/Moblin/RemoteControl/Web/js/remote.mjs
@@ -481,6 +481,8 @@ function updateGlobalToggles() {
   toggleButtonStyle("btn-show-title", state.global.showTitle);
   toggleButtonStyle("btn-info-box", state.global.showStats);
   toggleButtonStyle("btn-more-stats", state.global.showMoreStats);
+  toggleButtonStyle("btn-show-clock", state.global.showClock);
+  document.getElementById("clock-details").open = state.global.showClock;
 }
 
 function setTextColor(teamNumber, value) {
@@ -848,6 +850,9 @@ window.addEventListener("DOMContentLoaded", async () => {
   });
   addOnClick("btn-more-stats", () => {
     toggleButtonState("showMoreStats");
+  });
+  addOnClick("btn-show-clock", () => {
+    toggleButtonState("showClock");
   });
   addOnClick("btn-info-box", () => {
     toggleButtonState("showStats");

--- a/Moblin/RemoteControl/Web/remote.html
+++ b/Moblin/RemoteControl/Web/remote.html
@@ -19,22 +19,27 @@
       </div>
 
       <!-- Persistent Controls (Clock & Info) -->
-      <div class="card grid grid-cols-4 gap-2 items-center shadow-xl">
-        <button id="toggle-clock" class="btn btn-top bg-indigo-600 text-white border-none">
-          Clock
-        </button>
-        <input
-          type="text"
-          id="clock"
-          placeholder="0:00"
-          class="btn-top font-mono text-lg text-indigo-400 bg-black rounded"
-        />
-        <select id="clock-maximum" class="btn-top bg-black rounded"></select>
-        <select id="clock-direction" class="btn-top bg-black rounded">
-          <option value="up">Up</option>
-          <option value="down">Down</option>
-        </select>
-      </div>
+      <details id="clock-details">
+        <summary>
+          <button id="btn-show-clock" class="btn h-9 text-[10px]">Show/Hide Clock</button>
+        </summary>
+        <div class="card grid grid-cols-4 gap-2 items-center shadow-xl">
+          <button id="toggle-clock" class="btn btn-top bg-indigo-600 text-white border-none">
+            Clock
+          </button>
+          <input
+            type="text"
+            id="clock"
+            placeholder="0:00"
+            class="btn-top font-mono text-lg text-indigo-400 bg-black rounded"
+          />
+          <select id="clock-maximum" class="btn-top bg-black rounded"></select>
+          <select id="clock-direction" class="btn-top bg-black rounded">
+            <option value="up">Up</option>
+            <option value="down">Down</option>
+          </select>
+        </div>
+      </details>
 
       <details>
         <summary>HISTORICAL SCORES</summary>

--- a/Moblin/Various/Model/ModelScoreboard.swift
+++ b/Moblin/Various/Model/ModelScoreboard.swift
@@ -110,7 +110,8 @@ private let genericSetsConfig = RemoteControlScoreboardMatchConfig(
         changePossessionOnScore: false,
         showTitle: false,
         showStats: false,
-        showMoreStats: false
+        showMoreStats: false,
+        showClock: true
     ),
     controls: [
         "primaryScore": .init(type: "counter", label: "Pt", periodReset: true),
@@ -455,6 +456,7 @@ extension Model {
             config.global.showTitle = modular.showTitle
             config.global.showStats = modular.showGlobalStatsBlock
             config.global.showMoreStats = modular.showMoreStats
+            config.global.showClock = modular.showClock
             config.global.title = modular.title
             config.global.timer = modular.clock.format()
             switch modular.clock.direction {
@@ -550,6 +552,9 @@ extension Model {
         }
         if let show2nd = config.global.showMoreStats {
             modular.showMoreStats = show2nd
+        }
+        if let showClock = config.global.showClock {
+            modular.showClock = showClock
         }
         modular.home.name = config.team1.name
         modular.away.name = config.team2.name

--- a/Moblin/Various/Settings/SettingsScene.swift
+++ b/Moblin/Various/Settings/SettingsScene.swift
@@ -2966,6 +2966,7 @@ class SettingsWidgetModularScoreboard: Codable, ObservableObject {
     @Published var showTitle: Bool = false
     @Published var showMoreStats: Bool = false
     @Published var showGlobalStatsBlock: Bool = false
+    @Published var showClock: Bool = true
 
     enum CodingKeys: CodingKey {
         case home,
@@ -2981,7 +2982,8 @@ class SettingsWidgetModularScoreboard: Codable, ObservableObject {
              showTitle,
              stacked,
              showMoreStats,
-             showGlobalStatsBlock
+             showGlobalStatsBlock,
+             showClock
     }
 
     init() {}
@@ -3001,6 +3003,7 @@ class SettingsWidgetModularScoreboard: Codable, ObservableObject {
         try container.encode(.showTitle, showTitle)
         try container.encode(.showMoreStats, showMoreStats)
         try container.encode(.showGlobalStatsBlock, showGlobalStatsBlock)
+        try container.encode(.showClock, showClock)
     }
 
     required init(from decoder: Decoder) throws {
@@ -3018,6 +3021,7 @@ class SettingsWidgetModularScoreboard: Codable, ObservableObject {
         showTitle = container.decode(.showTitle, Bool.self, false)
         showMoreStats = container.decode(.showMoreStats, Bool.self, false)
         showGlobalStatsBlock = container.decode(.showGlobalStatsBlock, Bool.self, false)
+        showClock = container.decode(.showClock, Bool.self, true)
     }
 
     private static func createHomeTeam() -> SettingsWidgetModularScoreboardTeam {

--- a/Moblin/VideoEffects/Scoreboard/ScoreboardEffectModularView.swift
+++ b/Moblin/VideoEffects/Scoreboard/ScoreboardEffectModularView.swift
@@ -156,10 +156,12 @@ struct ScoreboardEffectModularView: View {
                                 .font(.system(size: fontSize() * 0.6))
                                 .minimumScaleFactor(0.1)
                         }
-                        Text(config.global.timer)
-                            .font(.system(size: fontSize() * 0.9))
-                            .monospacedDigit()
-                            .minimumScaleFactor(0.1)
+                        if modular.showClock {
+                            Text(config.global.timer)
+                                .font(.system(size: fontSize() * 0.9))
+                                .monospacedDigit()
+                                .minimumScaleFactor(0.1)
+                        }
                     }
                     .frame(width: fontSize() * 3.5, height: teamRowFullHeight)
                 } else {

--- a/Moblin/VideoEffects/Scoreboard/ScoreboardEffectModularView.swift
+++ b/Moblin/VideoEffects/Scoreboard/ScoreboardEffectModularView.swift
@@ -378,7 +378,7 @@ struct ScoreboardEffectModularView: View {
     @ViewBuilder
     private func infoBox() -> some View {
         if modular.showGlobalStatsBlock {
-            let stats = config.infoBoxStats()
+            let stats = config.infoBoxStats(showClock: modular.showClock)
             if !stats.isEmpty {
                 let rowHeight = CGFloat(modular.rowHeight)
                 let fullHeight = rowHeight + (modular.showMoreStats ? rowHeight * 0.6 : 0)

--- a/Moblin/View/Settings/Scenes/Widgets/Widget/Scoreboard/WidgetScoreboardModularSettingsView.swift
+++ b/Moblin/View/Settings/Scenes/Widgets/Widget/Scoreboard/WidgetScoreboardModularSettingsView.swift
@@ -155,6 +155,10 @@ struct WidgetScoreboardModularGeneralSettingsView: View {
                         .onChange(of: modular.showGlobalStatsBlock) { _ in
                             updated()
                         }
+                    Toggle("Show clock", isOn: $modular.showClock)
+                        .onChange(of: modular.showClock) { _ in
+                            updated()
+                        }
                     Toggle("Bold", isOn: $modular.isBold)
                         .onChange(of: modular.isBold) { _ in
                             updated()

--- a/Moblin/View/Settings/Scenes/Widgets/Widget/Scoreboard/WidgetScoreboardModularSettingsView.swift
+++ b/Moblin/View/Settings/Scenes/Widgets/Widget/Scoreboard/WidgetScoreboardModularSettingsView.swift
@@ -155,7 +155,7 @@ struct WidgetScoreboardModularGeneralSettingsView: View {
                         .onChange(of: modular.showGlobalStatsBlock) { _ in
                             updated()
                         }
-                    Toggle("Show clock", isOn: $modular.showClock)
+                    Toggle("Clock", isOn: $modular.showClock)
                         .onChange(of: modular.showClock) { _ in
                             updated()
                         }


### PR DESCRIPTION
This superseeds https://github.com/eerimoq/moblin/pull/323

Add a toggle to show/hide the clock in the generic scoreboard.
The state of the toggle is also used to show/hide the clock controls in the remote (through the use of the details/summary disclosure)