### PR TITLE
Add support for Kick show view count setting.

### DIFF
--- a/Moblin/StreamingPlatforms/Kick/KickApi.swift
+++ b/Moblin/StreamingPlatforms/Kick/KickApi.swift
@@ -351,6 +351,13 @@ class KickApi {
                     onComplete: onComplete)
     }
 
+    func setShowViewCount(channelId: String, enabled: Bool, onComplete: @escaping (OperationResult) -> Void) {
+        doWebV1Request(method: "PATCH",
+                       subPath: "channels/\(channelId)/settings",
+                       body: ["show_view_count": enabled],
+                       onComplete: onComplete)
+    }
+
     func setSubscribersOnlyMode(enabled: Bool, onComplete: @escaping (OperationResult) -> Void) {
         doV2Request(method: "PUT",
                     subPath: "channels/\(slug)/chatroom",
@@ -530,12 +537,25 @@ class KickApi {
         doRequest(method: method, subPath: "internal/v1/\(subPath)", body: body, onComplete: onComplete)
     }
 
+    private func doWebV1Request(method: String,
+                                subPath: String,
+                                body: [String: Any]? = nil,
+                                onComplete: @escaping (OperationResult) -> Void)
+    {
+        doRequest(method: method,
+                  subPath: "v1/\(subPath)",
+                  body: body,
+                  baseUrl: "https://web.kick.com/api/",
+                  onComplete: onComplete)
+    }
+
     private func doRequest(method: String,
                            subPath: String,
                            body: [String: Any]? = nil,
+                           baseUrl: String = "https://kick.com/api/",
                            onComplete: @escaping (OperationResult) -> Void)
     {
-        guard let url = URL(string: "https://kick.com/api/\(subPath)") else {
+        guard let url = URL(string: "\(baseUrl)\(subPath)") else {
             return
         }
         var request = URLRequest(url: url)

--- a/Moblin/Various/Model/ModelKick.swift
+++ b/Moblin/Various/Model/ModelKick.swift
@@ -206,6 +206,14 @@ extension Model {
         createKickApi(stream: stream).setSubscribersOnlyMode(enabled: enabled, onComplete: onComplete)
     }
 
+    func setKickShowViewCount(enabled: Bool, onComplete: @escaping (OperationResult) -> Void) {
+        createKickApi(stream: stream).setShowViewCount(
+            channelId: stream.kickChatroomChannelId ?? "",
+            enabled: enabled,
+            onComplete: onComplete
+        )
+    }
+
     func createKickPoll(title: String,
                         options: [String],
                         duration: Int,

--- a/Moblin/View/ControlBar/QuickButton/Chat/QuickButtonChatModerationView.swift
+++ b/Moblin/View/ControlBar/QuickButton/Chat/QuickButtonChatModerationView.swift
@@ -827,6 +827,14 @@ private struct EmotesOnlyView: View {
     }
 }
 
+private struct ShowViewCountView: View {
+    let action: (Bool, @escaping (OperationResult) -> Void) -> Void
+
+    var body: some View {
+        ToggleActionView(text: "Show view count on channel", image: "eye", action: action)
+    }
+}
+
 private struct NavigationLinkView<Content: View>: View {
     let text: LocalizedStringKey
     let image: String
@@ -922,6 +930,7 @@ private struct KickView: View {
                     FollowersOnlyView(durations: [60, 300, 600, 3600], action: followersOnlyAction)
                     SubscribersOnlyView(action: model.setKickSubscribersOnlyMode)
                     EmotesOnlyView(action: model.setKickEmoteOnlyMode)
+                    ShowViewCountView(action: model.setKickShowViewCount)
                 }
                 Section {
                     ForEach(ModActionType.allCases, id: \.self) {


### PR DESCRIPTION
Add support for Kick show view count setting.

Kick added a channel setting to toggle whether the live view count is shown on the channel. This adds a matching On/Off toggle in the Kick moderation panel