### PR TITLE
feat: support for osmo action 6

### DIFF
--- a/Moblin/Integrations/Dji/DjiDevice/DjiDevice.swift
+++ b/Moblin/Integrations/Dji/DjiDevice/DjiDevice.swift
@@ -321,7 +321,10 @@ extension DjiDevice: CBPeripheralDelegate {
         switch model {
         case .osmoAction2, .osmoAction3:
             sendStartStreaming()
-        case .osmoAction4:
+        case .osmoAction4, .osmoAction6:
+            // The Osmo Action 6 uses the same configure byte (0x08) as the OA4,
+            // not the 0x1A value used by the OA5 Pro / Osmo 360. Confirmed
+            // against a BTSnoop capture of the official DJI app.
             guard let imageStabilization else {
                 return
             }
@@ -331,7 +334,7 @@ extension DjiDevice: CBPeripheralDelegate {
                                              type: configureType,
                                              payload: payload.encode()))
             setState(state: .configuring)
-        case .osmoAction5Pro, .osmoAction6, .osmo360:
+        case .osmoAction5Pro, .osmo360:
             guard let imageStabilization else {
                 return
             }
@@ -369,6 +372,22 @@ extension DjiDevice: CBPeripheralDelegate {
             // other DJI camera Moblin supports. Reverse-engineered from a
             // PacketLogger capture of the official DJI Mimo app.
             let payload = DjiStartStreamingMessagePayloadPocket4(
+                rtmpUrl: rtmpUrl,
+                resolution: resolution,
+                fps: fps,
+                bitrateKbps: bitrateKbps
+            )
+            writeMessage(message: DjiMessage(target: startStreamingTarget,
+                                             id: startStreamingTransactionId,
+                                             type: startStreamingType,
+                                             payload: payload.encode()))
+        case .osmoAction6:
+            // The Osmo Action 6 uses the same JSON-wrapped start-streaming
+            // payload style as the Pocket 4 (not the legacy binary format), but
+            // pins the codec to AVC. Reverse-engineered from a BTSnoop capture of
+            // the official DJI app. This is what lets heavier image-stabilization
+            // modes stream without lag.
+            let payload = DjiStartStreamingMessagePayloadOsmoAction6(
                 rtmpUrl: rtmpUrl,
                 resolution: resolution,
                 fps: fps,

--- a/Moblin/Integrations/Dji/DjiDevice/DjiDeviceMessage.swift
+++ b/Moblin/Integrations/Dji/DjiDevice/DjiDeviceMessage.swift
@@ -132,6 +132,55 @@ struct DjiStartStreamingMessagePayloadPocket4 {
     }
 }
 
+private struct StartStreamingPayloadOsmoAction6: Codable {
+    let rtmpAddress: String
+    let watermark: Int
+    let codec: String
+    let EnhancedRTMP: Bool
+    let supportStopLive: Bool
+}
+
+struct DjiStartStreamingMessagePayloadOsmoAction6 {
+    // Same JSON-wrapped framing as the Pocket 4, but with the Osmo Action 6
+    // specific header/middle bytes and a JSON body that pins the codec to AVC
+    // (H.264) instead of HEVC. Reverse-engineered from a BTSnoop capture of the
+    // official DJI app streaming from an Osmo Action 6.
+    private static let header = Data([0x01, 0x9C, 0x00])
+    private static let middle = Data([0xFE, 0x00])
+    private static let padding = Data([0x00, 0x00, 0x00])
+
+    var rtmpUrl: String
+    var resolution: SettingsDjiDeviceResolution
+    var bitrateKbps: UInt16
+    var fps: Int
+
+    init(rtmpUrl: String, resolution: SettingsDjiDeviceResolution, fps: Int, bitrateKbps: UInt16) {
+        self.rtmpUrl = rtmpUrl
+        self.resolution = resolution
+        self.fps = fps
+        self.bitrateKbps = bitrateKbps
+    }
+
+    func encode() -> Data {
+        let payload = StartStreamingPayloadOsmoAction6(rtmpAddress: rtmpUrl,
+                                                       watermark: 0,
+                                                       codec: "AVC",
+                                                       EnhancedRTMP: false,
+                                                       supportStopLive: false)
+        let data = (try? JSONEncoder().encode(payload)) ?? Data()
+        let writer = ByteWriter()
+        writer.writeBytes(Self.header)
+        writer.writeUInt8(toDjiResolution(resolution: resolution))
+        writer.writeUInt16Le(bitrateKbps)
+        writer.writeBytes(Self.middle)
+        writer.writeUInt8(toDjiFps(fps: fps))
+        writer.writeBytes(Self.padding)
+        writer.writeUInt16Le(UInt16(truncatingIfNeeded: data.count))
+        writer.writeBytes(data)
+        return writer.data
+    }
+}
+
 struct DjiStopStreamingMessagePayload {
     static let payload = Data([0x01, 0x01, 0x1A, 0x00, 0x01, 0x02])
 


### PR DESCRIPTION
Implement initial OA6 protocol support based on Bluetooth capture analysis

Reverse-engineered the OA6 protocol from a Bluetooth capture of the Mimo app (simon_offiziell) using Claude 4.7 and implemented a minimal change set.

Testing with an Osmo Action 6 shows that lag issues in certain stabilization modes are resolved. Streaming can now be started and behaves similarly to the existing OA4 flow.

Further testing is needed to validate stability and uncover any remaining issues.