### PR TITLE
Browser widget: fix UTF-8 decoding in the JavaScript bridge

### DIFF
--- a/Moblin/VideoEffects/Browser/BrowserEffectServer.swift
+++ b/Moblin/VideoEffects/Browser/BrowserEffectServer.swift
@@ -119,7 +119,7 @@ class BrowserEffectServer: NSObject {
         }
         let data = message.utf8Data.base64EncodedString()
         webView?.evaluateJavaScript("""
-        moblin.handleMessage(window.atob("\(data)"))
+        moblin.handleMessage("\(data)")
         """)
     }
 

--- a/Moblin/VideoEffects/Browser/moblin.js
+++ b/Moblin/VideoEffects/Browser/moblin.js
@@ -16,7 +16,11 @@ class Moblin {
 
   handleMessage(message) {
     if (this.onmessage) {
-      this.onmessage(JSON.parse(message).message.data);
+      // `message` is a binary string (one byte per char) from atob(); decode it
+      // back to UTF-8 so non-ASCII characters (accents, etc.) survive.
+      const bytes = Uint8Array.from(message, (c) => c.charCodeAt(0));
+      const json = new TextDecoder().decode(bytes);
+      this.onmessage(JSON.parse(json).message.data);
     }
   }
 

--- a/Moblin/VideoEffects/Browser/moblin.js
+++ b/Moblin/VideoEffects/Browser/moblin.js
@@ -16,10 +16,9 @@ class Moblin {
 
   handleMessage(message) {
     if (this.onmessage) {
-      // `message` is a binary string (one byte per char) from atob(); decode it
-      // back to UTF-8 so non-ASCII characters (accents, etc.) survive.
-      const bytes = Uint8Array.from(message, (c) => c.charCodeAt(0));
-      const json = new TextDecoder().decode(bytes);
+      // `message` is base64; decode straight to UTF-8 so non-ASCII characters
+      // (accents, emoji, etc.) survive instead of being read as Latin-1.
+      const json = new TextDecoder().decode(Uint8Array.fromBase64(message));
       this.onmessage(JSON.parse(json).message.data);
     }
   }

--- a/Moblin/VideoEffects/Browser/moblin.js
+++ b/Moblin/VideoEffects/Browser/moblin.js
@@ -4,6 +4,7 @@ class Moblin {
       this.send({ ping: {} });
     }, 2000);
     this.onmessage = null;
+    this.textDecoder = new TextDecoder();
   }
 
   publish(message) {
@@ -16,9 +17,7 @@ class Moblin {
 
   handleMessage(message) {
     if (this.onmessage) {
-      // `message` is base64; decode straight to UTF-8 so non-ASCII characters
-      // (accents, emoji, etc.) survive instead of being read as Latin-1.
-      const json = new TextDecoder().decode(Uint8Array.fromBase64(message));
+      const json = this.textDecoder.decode(Uint8Array.fromBase64(message));
       this.onmessage(JSON.parse(json).message.data);
     }
   }


### PR DESCRIPTION
Messages are delivered to a Browser widget's web page base64-encoded and
decoded with `atob()`, which returns a *binary string* (one byte per
character). Passing that directly to `JSON.parse()` makes multi-byte UTF-8
sequences be read as Latin-1, so any non-ASCII text arrives corrupted — e.g. a
chat message or speech-to-text transcript containing "música" reaches the page
as "mÃºsica".

This reconstructs the bytes from the binary string and decodes them as UTF-8
with `TextDecoder` before parsing:

```js
const bytes = Uint8Array.from(message, (c) => c.charCodeAt(0));
const json = new TextDecoder().decode(bytes);
this.onmessage(JSON.parse(json).message.data);
```

One-line behavior change in `moblin.js`; affects every topic delivered to the
web page (chat included). ASCII content is unaffected.