### PR TITLE
Browser widget: expose speech-to-text transcript to web widgets

### DIFF
--- a/Moblin/Various/Model/ModelScene.swift
+++ b/Moblin/Various/Model/ModelScene.swift
@@ -1054,7 +1054,7 @@ extension Model {
             case .text:
                 addSceneTextEffects(sceneWidget, widget, &effects, &needsSpeechToText)
             case .browser:
-                addSceneBrowserEffects(sceneWidget, widget, scene, &effects)
+                addSceneBrowserEffects(sceneWidget, widget, scene, &effects, &needsSpeechToText)
             case .crop:
                 addSceneCropEffects(widget, scene, &effects)
             case .map:
@@ -1122,7 +1122,8 @@ extension Model {
         _ sceneWidget: SettingsSceneWidget,
         _ widget: SettingsWidget,
         _ scene: SettingsScene,
-        _ effects: inout [VideoEffect]
+        _ effects: inout [VideoEffect],
+        _ needsSpeechToText: inout Bool
     ) {
         guard let effect = browserEffects[widget.id], !effects.contains(effect) else {
             return
@@ -1132,6 +1133,9 @@ extension Model {
             crops: findWidgetCrops(scene: scene, sourceWidgetId: widget.id)
         )
         effects.append(effect)
+        if widget.browser.moblinAccess, widget.browser.speechToText {
+            needsSpeechToText = true
+        }
     }
 
     private func addSceneCropEffects(

--- a/Moblin/Various/Model/ModelSpeechToText.swift
+++ b/Moblin/Various/Model/ModelSpeechToText.swift
@@ -37,6 +37,9 @@ extension Model {
         for textEffect in textEffects.values {
             textEffect.clearSubtitles()
         }
+        for browserEffect in browserEffects.values {
+            browserEffect.sendSpeechToTextClear()
+        }
         speechToTextTextAligners.removeAll()
     }
 
@@ -61,6 +64,10 @@ extension Model {
                 if widget.widget.alerts.needsSubtitles {
                     return true
                 }
+            case .browser:
+                if widget.widget.browser.moblinAccess, widget.widget.browser.speechToText {
+                    return true
+                }
             default:
                 break
             }
@@ -71,6 +78,9 @@ extension Model {
     func speechToTextClear() {
         for textEffect in textEffects.values {
             textEffect.clearSubtitles()
+        }
+        for browserEffect in browserEffects.values {
+            browserEffect.sendSpeechToTextClear()
         }
         speechToTextTextAligners.removeAll()
         speechToTextAlertMatchOffset = 0
@@ -99,6 +109,12 @@ extension Model {
     ) {
         for textEffect in textEffects.values {
             textEffect.updateSubtitles(position: position, text: text, languageIdentifier: languageIdentifier)
+        }
+    }
+
+    private func speechToTextPartialResultBrowserWidgets(position: Int, text: String) {
+        for browserEffect in browserEffects.values {
+            browserEffect.sendSpeechToText(position: position, text: text)
         }
     }
 
@@ -146,6 +162,7 @@ extension Model: @preconcurrency SpeechToTextDelegate {
         }
         speechToTextPartialResultTextWidgets(position: position, text: text, languageIdentifier: nil)
         speechToTextPartialResultAlertsWidget(text: text)
+        speechToTextPartialResultBrowserWidgets(position: position, text: text)
     }
 }
 

--- a/Moblin/Various/Settings/SettingsScene.swift
+++ b/Moblin/Various/Settings/SettingsScene.swift
@@ -930,6 +930,7 @@ class SettingsWidgetBrowser: Codable, ObservableObject {
     @Published var baseFps: Float = 5.0
     @Published var styleSheet: String = ""
     @Published var moblinAccess: Bool = false
+    @Published var speechToText: Bool = false
 
     init() {}
 
@@ -942,6 +943,7 @@ class SettingsWidgetBrowser: Codable, ObservableObject {
         case fps
         case styleSheet
         case moblinAccess
+        case speechToText
     }
 
     func encode(to encoder: any Encoder) throws {
@@ -953,6 +955,7 @@ class SettingsWidgetBrowser: Codable, ObservableObject {
         try container.encode(.fps, baseFps)
         try container.encode(.styleSheet, styleSheet)
         try container.encode(.moblinAccess, moblinAccess)
+        try container.encode(.speechToText, speechToText)
     }
 
     required init(from decoder: any Decoder) throws {
@@ -969,6 +972,7 @@ class SettingsWidgetBrowser: Codable, ObservableObject {
         baseFps = container.decode(.fps, Float.self, 5.0)
         styleSheet = container.decode(.styleSheet, String.self, "")
         moblinAccess = container.decode(.moblinAccess, Bool.self, false)
+        speechToText = container.decode(.speechToText, Bool.self, false)
     }
 }
 

--- a/Moblin/VideoEffects/Browser/BrowserEffect.swift
+++ b/Moblin/VideoEffects/Browser/BrowserEffect.swift
@@ -55,6 +55,7 @@ final class BrowserEffect: VideoEffect, @unchecked Sendable {
     private var sceneWidget: SettingsSceneWidget?
     private var crops: [WidgetCrop] = []
     private let server: BrowserEffectServer
+    private let speechToText: Bool
     private var stopped = false
     private var suspended = false
     private let snapshotConfiguration: WKSnapshotConfiguration
@@ -73,6 +74,7 @@ final class BrowserEffect: VideoEffect, @unchecked Sendable {
         fps = baseFps
         isLoaded = false
         mode = widget.mode
+        speechToText = widget.speechToText
         width = Double(widget.width)
         height = Double(widget.height)
         snapshotConfiguration = WKSnapshotConfiguration()
@@ -111,6 +113,22 @@ final class BrowserEffect: VideoEffect, @unchecked Sendable {
     @MainActor
     func sendChatMessage(post: ChatPost) {
         server.sendChatMessage(post: post)
+    }
+
+    @MainActor
+    func sendSpeechToText(position: Int, text: String) {
+        guard speechToText else {
+            return
+        }
+        server.sendSpeechToText(position: position, text: text)
+    }
+
+    @MainActor
+    func sendSpeechToTextClear() {
+        guard speechToText else {
+            return
+        }
+        server.sendSpeechToTextClear()
     }
 
     var host: String {

--- a/Moblin/VideoEffects/Browser/BrowserEffectServer.swift
+++ b/Moblin/VideoEffects/Browser/BrowserEffectServer.swift
@@ -10,10 +10,13 @@ private enum PublishMessage: Codable {
 
 private enum SubscribeTopic: Codable {
     case chat(prefix: String?)
+    case speechToText
 }
 
 private enum Message: Codable {
     case chat(message: ChatMessage)
+    case speechToText(position: Int, text: String)
+    case speechToTextClear
 }
 
 private struct ChatMessage: Codable {
@@ -55,6 +58,7 @@ private struct Chat {
 
 private class Subscriptions {
     var chat: Chat?
+    var speechToText = false
 }
 
 @MainActor
@@ -103,6 +107,20 @@ class BrowserEffectServer: NSObject {
             }
         }
         send(message: .message(data: .chat(message: .init(message: post))))
+    }
+
+    func sendSpeechToText(position: Int, text: String) {
+        guard subscriptions.speechToText else {
+            return
+        }
+        send(message: .message(data: .speechToText(position: position, text: text)))
+    }
+
+    func sendSpeechToTextClear() {
+        guard subscriptions.speechToText else {
+            return
+        }
+        send(message: .message(data: .speechToTextClear))
     }
 
     private func handlePingTimer() {
@@ -161,6 +179,8 @@ class BrowserEffectServer: NSObject {
         switch topic {
         case let .chat(prefix: prefix):
             subscriptions.chat = .init(prefix: prefix)
+        case .speechToText:
+            subscriptions.speechToText = true
         }
     }
 }

--- a/Moblin/View/Settings/Scenes/Widgets/Widget/Browser/WidgetBrowserSettingsView.swift
+++ b/Moblin/View/Settings/Scenes/Widgets/Widget/Browser/WidgetBrowserSettingsView.swift
@@ -145,6 +145,19 @@ struct WidgetBrowserSettingsView: View {
                 "Give the webpage access to various data in Moblin, for example chat messages and your location."
             )
         }
+        if browser.moblinAccess {
+            Section {
+                Toggle("Speech to text", isOn: $browser.speechToText)
+                    .onChange(of: browser.speechToText) { _ in
+                        model.resetSelectedScene(changeScene: false)
+                    }
+            } footer: {
+                Text("""
+                Send the speech to text transcript (the same text the subtitles feature uses) \
+                to the webpage.
+                """)
+            }
+        }
         WidgetEffectsView(model: model, widget: widget)
     }
 }

--- a/README.md
+++ b/README.md
@@ -351,6 +351,25 @@ moblin.onmessage = (message) => {
 };
 ```
 
+Add this code to your website to receive the speech to text transcript (the
+same text the subtitles feature uses). You must enable `Settings -> Scenes ->
+My browser widget -> Speech to text` as well. `text` is a sliding window of
+the latest transcript and `position` is the offset of its first character,
+counted from when speech to text started. The transcript is cleared after a
+few seconds of silence.
+
+```js
+moblin.subscribe({ speechToText: {} });
+moblin.onmessage = (message) => {
+  if (message.speechToText !== undefined) {
+    console.log(message.speechToText.position, message.speechToText.text);
+  }
+  if (message.speechToTextClear !== undefined) {
+    console.log("Transcript cleared");
+  }
+};
+```
+
 ## Specification
 
 Topics to subscribe to are defined by `SubscribeTopic` in


### PR DESCRIPTION
## What

Adds a `speechToText` subscribe topic to the Browser widget JavaScript API,
mirroring the existing `chat` topic. A subscribed web page receives the
recognized transcript — the same text the subtitles feature already produces —
via `moblin.onmessage`:

```js
moblin.subscribe({ speechToText: {} });
moblin.onmessage = (message) => {
  if (message.speechToText !== undefined) {
    console.log(message.speechToText.position, message.speechToText.text);
  }
  if (message.speechToTextClear !== undefined) {
    // Transcript was cleared after silence.
  }
};
```

No new data is exposed: it is the same transcript the Subtitles feature and
the speech-to-text Alert trigger already use, only routed to the widget. It is
gated by the existing "Moblin access" setting plus a new per-widget "Speech to
text" toggle.

## Design

- **Per-widget toggle, no hot-path change.** Following your feedback about
  efficiency, the trigger is a per-widget Browser setting (like
  `needsSubtitles` on text/alerts widgets): `isSpeechToTextNeeded()` is decided
  from settings at scene update time, so the recognizer starts/stops without
  any periodic re-evaluation. The periodic timers are untouched.
- **Payload mirrors the internal delegate.** Messages carry `text` (the
  sliding transcript window) and `position` (absolute offset of its first
  character), exactly what `speechToTextPartialResult(position:text:)`
  delivers, so web pages can dedupe partial updates the same way the alerts
  widget does internally. A `speechToTextClear` message is sent when the
  transcript clears (silence timeout and recognizer stop), matching what text
  widgets get via `clearSubtitles()`.
- **Per-widget delivery gate.** `BrowserEffect` only forwards the transcript
  when its own widget's toggle is on — with two browser widgets, a page whose
  widget has the toggle off never receives speech, even while the recognizer
  runs for the other one. The toggle is the user's per-page consent for
  receiving their speech.
- **Settings compatibility:** the new field decodes with `false` as default,
  old configs are unaffected.

## Use cases

Custom caption overlays, "say a phrase to trigger an animation", voice-driven
widgets — same idea as the existing speech-to-text Alert trigger, available to
any web widget.

(My own use case: a voice-assistant widget. On iOS, `getUserMedia` inside the
widget's webview fights the broadcast's `AVAudioSession` — grabbing the mic
switches the live input route. Riding on Moblin's existing recognizer avoids
that entirely.)

## Testing

- `make style-check`, `make lint` (swiftlint --strict), `make spell-check` and
  the full CI workflow (including the Xcode build) green.
- Tested on device: a Browser widget pointing at a test page subscribes to
  `speechToText`; with "Moblin access" + "Speech to text" on, the page receives
  the live transcript (and `speechToTextClear` after silence) while streaming,
  with no microphone access from the webview.