### PR TITLE
Add split distance tracking for multi-day streams and lap segments.

### DIFF
--- a/Moblin/RemoteControl/RemoteControl.swift
+++ b/Moblin/RemoteControl/RemoteControl.swift
@@ -544,6 +544,7 @@ struct RemoteControlRemoteSceneDataTextStats: Codable {
     var averageSpeed: String
     var altitude: String
     var distance: String
+    var splitDistance: String
     var slope: String
     var conditions: String?
     var temperature: Measurement<UnitTemperature>?
@@ -582,6 +583,7 @@ struct RemoteControlRemoteSceneDataTextStats: Codable {
         averageSpeed = stats.averageSpeed
         altitude = stats.altitude
         distance = stats.distance
+        splitDistance = stats.splitDistance
         slope = stats.slope
         conditions = stats.conditions
         temperature = stats.temperature
@@ -621,6 +623,7 @@ struct RemoteControlRemoteSceneDataTextStats: Codable {
                         averageSpeed: averageSpeed,
                         altitude: altitude,
                         distance: distance,
+                        splitDistance: splitDistance,
                         slope: slope,
                         conditions: conditions,
                         temperature: temperature,

--- a/Moblin/Various/Model/ModelChatBot.swift
+++ b/Moblin/Various/Model/ModelChatBot.swift
@@ -115,6 +115,8 @@ extension Model {
             handleChatBotMessageMapZoomOut(command: command)
         case "location data reset":
             handleChatBotMessageLocationDataReset(command: command)
+        case "location split":
+            handleChatBotMessageLocationSplit(command: command)
         case "snapshot":
             handleChatBotMessageSnapshot(command: command)
         case "mute":
@@ -255,6 +257,15 @@ extension Model {
             command: command
         ) {
             self.resetLocationData()
+        }
+    }
+
+    private func handleChatBotMessageLocationSplit(command: ChatBotCommand) {
+        executeIfUserAllowedToUseChatBot(
+            permissions: database.chat.botCommandPermissions.locationSplit,
+            command: command
+        ) {
+            self.splitLocationData()
         }
     }
 

--- a/Moblin/Various/Model/ModelChatBot.swift
+++ b/Moblin/Various/Model/ModelChatBot.swift
@@ -115,7 +115,7 @@ extension Model {
             handleChatBotMessageMapZoomOut(command: command)
         case "location data reset":
             handleChatBotMessageLocationDataReset(command: command)
-        case "location split":
+        case "location data split":
             handleChatBotMessageLocationSplit(command: command)
         case "snapshot":
             handleChatBotMessageSnapshot(command: command)

--- a/Moblin/Various/Model/ModelChatBot.swift
+++ b/Moblin/Various/Model/ModelChatBot.swift
@@ -115,6 +115,8 @@ extension Model {
             handleChatBotMessageMapZoomOut(command: command)
         case "location data reset":
             handleChatBotMessageLocationDataReset(command: command)
+        case "location split":
+            handleChatBotMessageLocationSplit(command: command)
         case "snapshot":
             handleChatBotMessageSnapshot(command: command)
         case "mute":
@@ -255,6 +257,15 @@ extension Model {
             command: command
         ) {
             self.resetLocationData()
+        }
+    }
+
+    private func handleChatBotMessageLocationSplit(command: ChatBotCommand) {
+        executeIfUserAllowedToUseChatBot(
+            permissions: database.chat.botCommandPermissions.location,
+            command: command
+        ) {
+            self.splitLocationData()
         }
     }
 

--- a/Moblin/Various/Model/ModelChatBot.swift
+++ b/Moblin/Various/Model/ModelChatBot.swift
@@ -265,7 +265,7 @@ extension Model {
             permissions: database.chat.botCommandPermissions.location,
             command: command
         ) {
-            self.splitLocationData()
+            self.resetSplitDistance()
         }
     }
 

--- a/Moblin/Various/Model/ModelLocation.swift
+++ b/Moblin/Various/Model/ModelLocation.swift
@@ -23,13 +23,22 @@ extension Model {
 
     private func resetDistance() {
         database.location.distance = 0.0
+        database.location.splitDistance = 0.0
         latestKnownLocation = nil
+    }
+
+    private func resetSplitDistance() {
+        database.location.splitDistance = 0.0
     }
 
     func resetLocationData() {
         resetDistance()
         resetAverageSpeed()
         resetSlope()
+    }
+
+    func splitLocationData() {
+        resetSplitDistance()
     }
 
     func isLocationEnabled() -> Bool {
@@ -82,6 +91,7 @@ extension Model {
             let distance = location?.distance(from: latestKnownLocation) ?? 0
             if distance > latestKnownLocation.horizontalAccuracy {
                 database.location.distance += distance
+                database.location.splitDistance += distance
                 self.latestKnownLocation = location
             }
         } else {
@@ -123,6 +133,10 @@ extension Model {
 
     func getDistance() -> String {
         format(distance: database.location.distance)
+    }
+
+    func getSplitDistance() -> String {
+        format(distance: database.location.splitDistance)
     }
 
     func isShowingStatusLocation() -> Bool {

--- a/Moblin/Various/Model/ModelLocation.swift
+++ b/Moblin/Various/Model/ModelLocation.swift
@@ -27,7 +27,7 @@ extension Model {
         latestKnownLocation = nil
     }
 
-    private func resetSplitDistance() {
+    func resetSplitDistance() {
         database.location.splitDistance = 0.0
     }
 
@@ -35,10 +35,6 @@ extension Model {
         resetDistance()
         resetAverageSpeed()
         resetSlope()
-    }
-
-    func splitLocationData() {
-        resetSplitDistance()
     }
 
     func isLocationEnabled() -> Bool {

--- a/Moblin/Various/Model/ModelScene.swift
+++ b/Moblin/Various/Model/ModelScene.swift
@@ -1521,6 +1521,7 @@ extension Model {
                 averageSpeed: format(speed: averageSpeed),
                 altitude: format(altitude: location?.altitude ?? 0),
                 distance: getDistance(),
+                splitDistance: getSplitDistance(),
                 slope: "\(Int(slopePercent))%",
                 conditions: weather?.symbolName,
                 temperature: weather?.temperature,

--- a/Moblin/Various/Settings/SettingsChat.swift
+++ b/Moblin/Various/Settings/SettingsChat.swift
@@ -165,6 +165,7 @@ class SettingsChatBotPermissions: Codable {
     var stream: SettingsChatBotPermissionsCommand = .init(moderatorsEnabled: false)
     var widget: SettingsChatBotPermissionsCommand = .init()
     var location: SettingsChatBotPermissionsCommand = .init()
+    var locationSplit: SettingsChatBotPermissionsCommand = .init()
     var ai: SettingsChatBotPermissionsCommand = .init()
     var twitch: SettingsChatBotPermissionsCommand = .init()
     var gimbal: SettingsChatBotPermissionsCommand = .init()
@@ -188,6 +189,7 @@ class SettingsChatBotPermissions: Codable {
         case stream
         case widget
         case location
+        case locationSplit
         case ai
         case twitch
         case gimbal
@@ -213,6 +215,7 @@ class SettingsChatBotPermissions: Codable {
         try container.encode(.stream, stream)
         try container.encode(.widget, widget)
         try container.encode(.location, location)
+        try container.encode(.locationSplit, locationSplit)
         try container.encode(.ai, ai)
         try container.encode(.twitch, twitch)
         try container.encode(.gimbal, gimbal)
@@ -240,6 +243,7 @@ class SettingsChatBotPermissions: Codable {
         stream = container.decode(.stream, SettingsChatBotPermissionsCommand.self, .init())
         widget = container.decode(.widget, SettingsChatBotPermissionsCommand.self, .init())
         location = container.decode(.location, SettingsChatBotPermissionsCommand.self, .init())
+        locationSplit = container.decode(.locationSplit, SettingsChatBotPermissionsCommand.self, .init())
         ai = container.decode(.ai, SettingsChatBotPermissionsCommand.self, .init())
         twitch = container.decode(.twitch, SettingsChatBotPermissionsCommand.self, .init())
         gimbal = container.decode(.gimbal, SettingsChatBotPermissionsCommand.self, .init())

--- a/Moblin/Various/Settings/SettingsChat.swift
+++ b/Moblin/Various/Settings/SettingsChat.swift
@@ -165,7 +165,6 @@ class SettingsChatBotPermissions: Codable {
     var stream: SettingsChatBotPermissionsCommand = .init(moderatorsEnabled: false)
     var widget: SettingsChatBotPermissionsCommand = .init()
     var location: SettingsChatBotPermissionsCommand = .init()
-    var locationSplit: SettingsChatBotPermissionsCommand = .init()
     var ai: SettingsChatBotPermissionsCommand = .init()
     var twitch: SettingsChatBotPermissionsCommand = .init()
     var gimbal: SettingsChatBotPermissionsCommand = .init()
@@ -189,7 +188,6 @@ class SettingsChatBotPermissions: Codable {
         case stream
         case widget
         case location
-        case locationSplit
         case ai
         case twitch
         case gimbal
@@ -215,7 +213,6 @@ class SettingsChatBotPermissions: Codable {
         try container.encode(.stream, stream)
         try container.encode(.widget, widget)
         try container.encode(.location, location)
-        try container.encode(.locationSplit, locationSplit)
         try container.encode(.ai, ai)
         try container.encode(.twitch, twitch)
         try container.encode(.gimbal, gimbal)
@@ -243,7 +240,6 @@ class SettingsChatBotPermissions: Codable {
         stream = container.decode(.stream, SettingsChatBotPermissionsCommand.self, .init())
         widget = container.decode(.widget, SettingsChatBotPermissionsCommand.self, .init())
         location = container.decode(.location, SettingsChatBotPermissionsCommand.self, .init())
-        locationSplit = container.decode(.locationSplit, SettingsChatBotPermissionsCommand.self, .init())
         ai = container.decode(.ai, SettingsChatBotPermissionsCommand.self, .init())
         twitch = container.decode(.twitch, SettingsChatBotPermissionsCommand.self, .init())
         gimbal = container.decode(.gimbal, SettingsChatBotPermissionsCommand.self, .init())

--- a/Moblin/Various/Settings/SettingsLocation.swift
+++ b/Moblin/Various/Settings/SettingsLocation.swift
@@ -72,6 +72,7 @@ class SettingsLocation: Codable, ObservableObject {
     @Published var enabled: Bool = false
     @Published var privacyRegions: [SettingsPrivacyRegion] = []
     @Published var distance: Double = 0.0
+    @Published var splitDistance: Double = 0.0
     @Published var resetWhenGoingLive: Bool = false
     @Published var desiredAccuracy: SettingsLocationDesiredAccuracy = .best
     @Published var distanceFilter: SettingsLocationDistanceFilter = .none
@@ -80,6 +81,7 @@ class SettingsLocation: Codable, ObservableObject {
         case enabled
         case privacyRegions
         case distance
+        case splitDistance
         case resetWhenGoingLive
         case desiredAccuracy
         case distanceFilter
@@ -90,6 +92,7 @@ class SettingsLocation: Codable, ObservableObject {
         try container.encode(.enabled, enabled)
         try container.encode(.privacyRegions, privacyRegions)
         try container.encode(.distance, distance)
+        try container.encode(.splitDistance, splitDistance)
         try container.encode(.resetWhenGoingLive, resetWhenGoingLive)
         try container.encode(.desiredAccuracy, desiredAccuracy)
         try container.encode(.distanceFilter, distanceFilter)
@@ -102,6 +105,7 @@ class SettingsLocation: Codable, ObservableObject {
         enabled = container.decode(.enabled, Bool.self, false)
         privacyRegions = container.decode(.privacyRegions, [SettingsPrivacyRegion].self, [])
         distance = container.decode(.distance, Double.self, 0.0)
+        splitDistance = container.decode(.splitDistance, Double.self, 0.0)
         resetWhenGoingLive = container.decode(.resetWhenGoingLive, Bool.self, false)
         desiredAccuracy = container.decode(.desiredAccuracy, SettingsLocationDesiredAccuracy.self, .best)
         distanceFilter = container.decode(.distanceFilter, SettingsLocationDistanceFilter.self, .none)

--- a/Moblin/VideoEffects/Text/TextEffect.swift
+++ b/Moblin/VideoEffects/Text/TextEffect.swift
@@ -15,6 +15,7 @@ struct TextEffectStats {
     let averageSpeed: String
     let altitude: String
     let distance: String
+    let splitDistance: String
     let slope: String
     let conditions: String?
     let temperature: Measurement<UnitTemperature>?

--- a/Moblin/VideoEffects/Text/TextEffectFormatter.swift
+++ b/Moblin/VideoEffects/Text/TextEffectFormatter.swift
@@ -111,6 +111,8 @@ class TextEffectFormatter {
                 formatAltitude(stats: stats)
             case .distance:
                 formatDistance(stats: stats)
+            case .splitDistance:
+                formatSplitDistance(stats: stats)
             case .slope:
                 formatSlope(stats: stats)
             case .timer:
@@ -255,6 +257,10 @@ class TextEffectFormatter {
 
     private func formatDistance(stats: TextEffectStats) {
         appendTextPart(value: stats.distance)
+    }
+
+    private func formatSplitDistance(stats: TextEffectStats) {
+        appendTextPart(value: stats.splitDistance)
     }
 
     private func formatSlope(stats: TextEffectStats) {

--- a/Moblin/VideoEffects/Text/TextFormatStringLoader.swift
+++ b/Moblin/VideoEffects/Text/TextFormatStringLoader.swift
@@ -16,6 +16,7 @@ enum TextFormatPart: Equatable {
     case averageSpeed
     case altitude
     case distance
+    case splitDistance
     case slope
     case timer
     case stopwatch
@@ -94,6 +95,8 @@ class TextFormatLoader {
                 } else if formatFromIndex.hasPrefix("{altitude}") {
                     loadItem(part: .altitude, offsetBy: 10)
                 } else if appendRunDistanceIfPresent(formatFromIndex: formatFromIndex) {
+                } else if formatFromIndex.hasPrefix("{splitdistance}") {
+                    loadItem(part: .splitDistance, offsetBy: 15)
                 } else if formatFromIndex.hasPrefix("{distance}") {
                     loadItem(part: .distance, offsetBy: 10)
                 } else if formatFromIndex.hasPrefix("{slope}") {

--- a/Moblin/View/Settings/Chat/ChatBotSettingsView.swift
+++ b/Moblin/View/Settings/Chat/ChatBotSettingsView.swift
@@ -267,7 +267,22 @@ private struct LocationPermissionsSettingsView: View {
                 permissions: permissions
             )
         } footer: {
-            Text("Resets distance, average speed and slope.")
+            Text("Resets distance, split distance, average speed and slope.")
+        }
+    }
+}
+
+private struct LocationSplitPermissionsSettingsView: View {
+    let permissions: SettingsChatBotPermissionsCommand
+
+    var body: some View {
+        Section {
+            PermissionsSettingsView(
+                title: "!moblin location split",
+                permissions: permissions
+            )
+        } footer: {
+            Text("Resets split distance only.")
         }
     }
 }
@@ -456,6 +471,7 @@ private struct ChatBotCommandsSettingsView: View {
             FixPermissionsSettingsView(permissions: permissions.fix)
             GimbalPermissionsSettingsView(permissions: permissions.gimbal)
             LocationPermissionsSettingsView(permissions: permissions.location)
+            LocationSplitPermissionsSettingsView(permissions: permissions.locationSplit)
             MacroPermissionsSettingsView(permissions: permissions.macro)
             MapPermissionsSettingsView(permissions: permissions.map)
             MuteUnmutePermissionsSettingsView(permissions: permissions.audio)

--- a/Moblin/View/Settings/Chat/ChatBotSettingsView.swift
+++ b/Moblin/View/Settings/Chat/ChatBotSettingsView.swift
@@ -263,15 +263,15 @@ private struct LocationPermissionsSettingsView: View {
     var body: some View {
         Section {
             PermissionsSettingsView(
-                title: String(localized: "!moblin location ..."),
+                title: "!moblin location ...",
                 permissions: permissions
             )
         } footer: {
             VStack(alignment: .leading) {
-                Text("!moblin location data reset")
+                Text(String("!moblin location data reset"))
                 Text("Reset distance, split distance, average speed and slope.")
                 Text("")
-                Text("!moblin location split")
+                Text(String("!moblin location data split"))
                 Text("Reset split distance only.")
             }
         }

--- a/Moblin/View/Settings/Chat/ChatBotSettingsView.swift
+++ b/Moblin/View/Settings/Chat/ChatBotSettingsView.swift
@@ -263,17 +263,17 @@ private struct LocationPermissionsSettingsView: View {
     var body: some View {
         Section {
             PermissionsSettingsView(
-                title: "!moblin location data reset",
-                permissions: permissions
-            )
-            PermissionsSettingsView(
-                title: "!moblin location split",
+                title: String(localized: "!moblin location ..."),
                 permissions: permissions
             )
         } footer: {
-            Text(
-                "Reset resets distance, split distance, average speed and slope. Split resets split distance only."
-            )
+            VStack(alignment: .leading) {
+                Text("!moblin location data reset")
+                Text("Reset distance, split distance, average speed and slope.")
+                Text("")
+                Text("!moblin location split")
+                Text("Reset split distance only.")
+            }
         }
     }
 }

--- a/Moblin/View/Settings/Chat/ChatBotSettingsView.swift
+++ b/Moblin/View/Settings/Chat/ChatBotSettingsView.swift
@@ -266,8 +266,14 @@ private struct LocationPermissionsSettingsView: View {
                 title: "!moblin location data reset",
                 permissions: permissions
             )
+            PermissionsSettingsView(
+                title: "!moblin location split",
+                permissions: permissions
+            )
         } footer: {
-            Text("Resets distance, average speed and slope.")
+            Text(
+                "Reset resets distance, split distance, average speed and slope. Split resets split distance only."
+            )
         }
     }
 }

--- a/Moblin/View/Settings/Location/LocationSettingsView.swift
+++ b/Moblin/View/Settings/Location/LocationSettingsView.swift
@@ -63,7 +63,7 @@ struct LocationSettingsView: View {
             Section {
                 Toggle("Reset when going live", isOn: $location.resetWhenGoingLive)
                 TextButtonView("Split") {
-                    model.splitLocationData()
+                    model.resetSplitDistance()
                 }
                 TextButtonView("Reset") {
                     model.resetLocationData()

--- a/Moblin/View/Settings/Location/LocationSettingsView.swift
+++ b/Moblin/View/Settings/Location/LocationSettingsView.swift
@@ -62,13 +62,18 @@ struct LocationSettingsView: View {
             }
             Section {
                 Toggle("Reset when going live", isOn: $location.resetWhenGoingLive)
+                TextButtonView("Split") {
+                    model.splitLocationData()
+                }
                 TextButtonView("Reset") {
                     model.resetLocationData()
                 }
             } header: {
                 Text("Location data")
             } footer: {
-                Text("Resets distance, average speed and slope.")
+                Text(
+                    "Split resets split distance only. Reset resets distance, split distance, average speed and slope."
+                )
             }
             if database.showAllSettings, stream !== fallbackStream {
                 ShortcutSectionView {

--- a/Moblin/View/Settings/Scenes/Widgets/Widget/Text/WidgetTextSettingsView.swift
+++ b/Moblin/View/Settings/Scenes/Widgets/Widget/Text/WidgetTextSettingsView.swift
@@ -744,6 +744,11 @@ private struct LocationVariablesView: View {
                         description: String(localized: "Show distance"),
                         text: $value
                     )
+                    VariableView(
+                        title: "{splitDistance}",
+                        description: String(localized: "Show split distance"),
+                        text: $value
+                    )
                     VariableView(title: "{slope}", description: String(localized: "Show slope"), text: $value)
                 }
             }

--- a/MoblinTests/TextEffectSuite.swift
+++ b/MoblinTests/TextEffectSuite.swift
@@ -107,6 +107,7 @@ struct TextEffectSuite {
                         averageSpeed: "",
                         altitude: "",
                         distance: "",
+                        splitDistance: "",
                         slope: "",
                         conditions: conditions,
                         temperature: nil,


### PR DESCRIPTION
Introduces {splitDistance} as a second distance counter that resets independently via a new Split button (or !moblin location split chatbot command), while the total {distance} and the existing Reset button remain unchanged.