### PR TITLE
Add per-source audio offset setting for all ingest types

### DIFF
--- a/Moblin/Media/HaishinKit/Media/Audio/AudioUnit.swift
+++ b/Moblin/Media/HaishinKit/Media/Audio/AudioUnit.swift
@@ -186,7 +186,12 @@ final class AudioUnit: NSObject, @unchecked Sendable {
 
     func addBufferedAudio(cameraId: UUID, name: String, latency: Double, audioOffset: Double = 0) {
         processorPipelineQueue.async {
-            self.addBufferedAudioInternal(cameraId: cameraId, name: name, latency: latency, audioOffset: audioOffset)
+            self.addBufferedAudioInternal(
+                cameraId: cameraId,
+                name: name,
+                latency: latency,
+                audioOffset: audioOffset
+            )
         }
     }
 
@@ -253,7 +258,12 @@ final class AudioUnit: NSObject, @unchecked Sendable {
         }
     }
 
-    private func addBufferedAudioInternal(cameraId: UUID, name: String, latency: Double, audioOffset: Double = 0) {
+    private func addBufferedAudioInternal(
+        cameraId: UUID,
+        name: String,
+        latency: Double,
+        audioOffset: Double = 0
+    ) {
         let bufferedAudio = BufferedAudio(
             cameraId: cameraId,
             name: name,

--- a/Moblin/Media/HaishinKit/Media/Audio/AudioUnit.swift
+++ b/Moblin/Media/HaishinKit/Media/Audio/AudioUnit.swift
@@ -184,9 +184,15 @@ final class AudioUnit: NSObject, @unchecked Sendable {
         }
     }
 
-    func addBufferedAudio(cameraId: UUID, name: String, latency: Double) {
+    func addBufferedAudio(cameraId: UUID, name: String, latency: Double, audioOffset: Double = 0) {
         processorPipelineQueue.async {
-            self.addBufferedAudioInternal(cameraId: cameraId, name: name, latency: latency)
+            self.addBufferedAudioInternal(cameraId: cameraId, name: name, latency: latency, audioOffset: audioOffset)
+        }
+    }
+
+    func setBufferedAudioOffset(cameraId: UUID, offset: Double) {
+        processorPipelineQueue.async {
+            self.bufferedAudios[cameraId]?.audioOffset = offset
         }
     }
 
@@ -247,7 +253,7 @@ final class AudioUnit: NSObject, @unchecked Sendable {
         }
     }
 
-    private func addBufferedAudioInternal(cameraId: UUID, name: String, latency: Double) {
+    private func addBufferedAudioInternal(cameraId: UUID, name: String, latency: Double, audioOffset: Double = 0) {
         let bufferedAudio = BufferedAudio(
             cameraId: cameraId,
             name: name,
@@ -255,6 +261,7 @@ final class AudioUnit: NSObject, @unchecked Sendable {
             processor: processor,
             manualOutput: false
         )
+        bufferedAudio.audioOffset = audioOffset
         bufferedAudio.delegate = self
         bufferedAudios[cameraId] = bufferedAudio
     }

--- a/Moblin/Media/HaishinKit/Media/Audio/BufferedAudio.swift
+++ b/Moblin/Media/HaishinKit/Media/Audio/BufferedAudio.swift
@@ -26,6 +26,7 @@ class BufferedAudio {
     weak var delegate: (any BufferedAudioSampleBufferDelegate)?
     private var hasBufferBeenAppended = false
     let latency: Double
+    var audioOffset: Double = 0
     private var stats = BufferedStats()
     private let manualOutput: Bool
 
@@ -171,7 +172,7 @@ class BufferedAudio {
                                        _ drift: Double) -> Bool
     {
         // Find the first frame that is ahead in time.
-        let nextPresentationTimeStamp = nextSampleBuffer.presentationTimeStamp.seconds + drift
+        let nextPresentationTimeStamp = nextSampleBuffer.presentationTimeStamp.seconds + drift + audioOffset
         let delta = nextPresentationTimeStamp - outputPresentationTimeStamp
         guard delta > 0 else {
             return false
@@ -187,7 +188,7 @@ class BufferedAudio {
                                      _ drift: Double) -> Bool
     {
         // Do not skip any buffers unless very far apart.
-        let candidatePresentationTimeStamp = candidateSampleBuffer.presentationTimeStamp.seconds + drift
+        let candidatePresentationTimeStamp = candidateSampleBuffer.presentationTimeStamp.seconds + drift + audioOffset
         let delta = candidatePresentationTimeStamp - outputPresentationTimeStamp
         if abs(delta) > 0.05 {
             isSyncingWithOutput = true

--- a/Moblin/Media/HaishinKit/Media/Audio/BufferedAudio.swift
+++ b/Moblin/Media/HaishinKit/Media/Audio/BufferedAudio.swift
@@ -188,7 +188,8 @@ class BufferedAudio {
                                      _ drift: Double) -> Bool
     {
         // Do not skip any buffers unless very far apart.
-        let candidatePresentationTimeStamp = candidateSampleBuffer.presentationTimeStamp.seconds + drift + audioOffset
+        let candidatePresentationTimeStamp = candidateSampleBuffer.presentationTimeStamp
+            .seconds + drift + audioOffset
         let delta = candidatePresentationTimeStamp - outputPresentationTimeStamp
         if abs(delta) > 0.05 {
             isSyncingWithOutput = true

--- a/Moblin/Media/HaishinKit/Media/Processor.swift
+++ b/Moblin/Media/HaishinKit/Media/Processor.swift
@@ -160,8 +160,12 @@ final class Processor: @unchecked Sendable {
         video.setBufferedVideoTargetLatency(cameraId: cameraId, latency: latency)
     }
 
-    func addBufferedAudio(cameraId: UUID, name: String, latency: Double) {
-        audio.addBufferedAudio(cameraId: cameraId, name: name, latency: latency)
+    func addBufferedAudio(cameraId: UUID, name: String, latency: Double, audioOffset: Double = 0) {
+        audio.addBufferedAudio(cameraId: cameraId, name: name, latency: latency, audioOffset: audioOffset)
+    }
+
+    func setBufferedAudioOffset(cameraId: UUID, offset: Double) {
+        audio.setBufferedAudioOffset(cameraId: cameraId, offset: offset)
     }
 
     func removeBufferedAudio(cameraId: UUID) {

--- a/Moblin/Various/Media.swift
+++ b/Moblin/Various/Media.swift
@@ -942,8 +942,12 @@ final class Media: NSObject, @unchecked Sendable {
         processor?.attachAudio(params: params)
     }
 
-    func addBufferedAudio(cameraId: UUID, name: String, latency: Double) {
-        processor?.addBufferedAudio(cameraId: cameraId, name: name, latency: latency)
+    func addBufferedAudio(cameraId: UUID, name: String, latency: Double, audioOffset: Double = 0) {
+        processor?.addBufferedAudio(cameraId: cameraId, name: name, latency: latency, audioOffset: audioOffset)
+    }
+
+    func setBufferedAudioOffset(cameraId: UUID, offset: Double) {
+        processor?.setBufferedAudioOffset(cameraId: cameraId, offset: offset)
     }
 
     func removeBufferedAudio(cameraId: UUID) {

--- a/Moblin/Various/Media.swift
+++ b/Moblin/Various/Media.swift
@@ -943,7 +943,12 @@ final class Media: NSObject, @unchecked Sendable {
     }
 
     func addBufferedAudio(cameraId: UUID, name: String, latency: Double, audioOffset: Double = 0) {
-        processor?.addBufferedAudio(cameraId: cameraId, name: name, latency: latency, audioOffset: audioOffset)
+        processor?.addBufferedAudio(
+            cameraId: cameraId,
+            name: name,
+            latency: latency,
+            audioOffset: audioOffset
+        )
     }
 
     func setBufferedAudioOffset(cameraId: UUID, offset: Double) {

--- a/Moblin/Various/Model/ModelRistServer.swift
+++ b/Moblin/Various/Model/ModelRistServer.swift
@@ -40,6 +40,10 @@ extension Model {
     func isRistStreamConnected(port: UInt16) -> Bool {
         database.ristServer.streams.first { $0.virtualDestinationPort == port }?.connected == true
     }
+
+    func setRistStreamAudioOffset(stream: SettingsRistServerStream) {
+        media.setBufferedAudioOffset(cameraId: stream.id, offset: stream.audioOffsetSeconds())
+    }
 }
 
 extension Model: @preconcurrency RistServerDelegate {
@@ -89,7 +93,12 @@ extension Model: @preconcurrency RistServerDelegate {
         makeToast(title: String(localized: "\(camera) connected"))
         let latency = stream.latencySeconds()
         media.addBufferedVideo(cameraId: stream.id, name: camera, latency: latency)
-        media.addBufferedAudio(cameraId: stream.id, name: camera, latency: latency)
+        media.addBufferedAudio(
+            cameraId: stream.id,
+            name: camera,
+            latency: latency,
+            audioOffset: stream.audioOffsetSeconds()
+        )
     }
 
     private func ristServerOnDisconnectedInternal(virtualDestinationPort: UInt16, reason _: String) {

--- a/Moblin/Various/Model/ModelRtmpServer.swift
+++ b/Moblin/Various/Model/ModelRtmpServer.swift
@@ -37,7 +37,12 @@ extension Model {
             self.makeToast(title: String(localized: "\(camera) connected"))
             let latency = stream.latencySeconds()
             self.media.addBufferedVideo(cameraId: stream.id, name: camera, latency: latency)
-            self.media.addBufferedAudio(cameraId: stream.id, name: camera, latency: latency)
+            self.media.addBufferedAudio(
+                cameraId: stream.id,
+                name: camera,
+                latency: latency,
+                audioOffset: stream.audioOffsetSeconds()
+            )
             self.markDjiIsStreamingIfNeeded(rtmpServerStreamId: stream.id)
         }
     }
@@ -94,6 +99,10 @@ extension Model {
 
     func rtmpServerEnabled() -> Bool {
         database.rtmpServer.enabled
+    }
+
+    func setRtmpStreamAudioOffset(stream: SettingsRtmpServerStream) {
+        media.setBufferedAudioOffset(cameraId: stream.id, offset: stream.audioOffsetSeconds())
     }
 }
 

--- a/Moblin/Various/Model/ModelSrtClient.swift
+++ b/Moblin/Various/Model/ModelSrtClient.swift
@@ -50,7 +50,16 @@ extension Model {
         let camera = stream.camera()
         makeToast(title: String(localized: "\(camera) connected"))
         media.addBufferedVideo(cameraId: cameraId, name: camera, latency: srtClientLatency)
-        media.addBufferedAudio(cameraId: cameraId, name: camera, latency: srtClientLatency)
+        media.addBufferedAudio(
+            cameraId: cameraId,
+            name: camera,
+            latency: srtClientLatency,
+            audioOffset: stream.audioOffsetSeconds()
+        )
+    }
+
+    func setSrtClientStreamAudioOffset(stream: SettingsSrtClientStream) {
+        media.setBufferedAudioOffset(cameraId: stream.id, offset: stream.audioOffsetSeconds())
     }
 
     private func srtClientDisconnectedInternal(cameraId: UUID) {

--- a/Moblin/Various/Model/ModelSrtlaServer.swift
+++ b/Moblin/Various/Model/ModelSrtlaServer.swift
@@ -59,8 +59,18 @@ extension Model: @preconcurrency SrtlaServerDelegate {
 
     private func srtlaServerOnClientStartInternal(cameraId: UUID, name: String) {
         makeToast(title: String(localized: "\(name) connected"))
+        let audioOffset = getSrtlaStream(id: cameraId)?.audioOffsetSeconds() ?? 0
         media.addBufferedVideo(cameraId: cameraId, name: name, latency: srtServerClientLatency)
-        media.addBufferedAudio(cameraId: cameraId, name: name, latency: srtServerClientLatency)
+        media.addBufferedAudio(
+            cameraId: cameraId,
+            name: name,
+            latency: srtServerClientLatency,
+            audioOffset: audioOffset
+        )
+    }
+
+    func setSrtlaStreamAudioOffset(stream: SettingsSrtlaServerStream) {
+        media.setBufferedAudioOffset(cameraId: stream.id, offset: stream.audioOffsetSeconds())
     }
 
     private func srtlaServerOnClientStopInternal(cameraId: UUID, name: String) {

--- a/Moblin/Various/Model/ModelWhepClient.swift
+++ b/Moblin/Various/Model/ModelWhepClient.swift
@@ -50,6 +50,10 @@ extension Model {
             media.removeBufferedAudio(cameraId: stream.id)
         }
     }
+
+    func setWhepStreamAudioOffset(stream: SettingsWhepClientStream) {
+        media.setBufferedAudioOffset(cameraId: stream.id, offset: stream.audioOffsetSeconds())
+    }
 }
 
 extension Model: @preconcurrency WhepClientDelegate {
@@ -62,7 +66,12 @@ extension Model: @preconcurrency WhepClientDelegate {
             self.makeToast(title: String(localized: "\(camera) connected"))
             let latency = stream.latencySeconds()
             self.media.addBufferedVideo(cameraId: stream.id, name: camera, latency: latency)
-            self.media.addBufferedAudio(cameraId: stream.id, name: camera, latency: latency)
+            self.media.addBufferedAudio(
+                cameraId: stream.id,
+                name: camera,
+                latency: latency,
+                audioOffset: stream.audioOffsetSeconds()
+            )
         }
     }
 

--- a/Moblin/Various/Model/ModelWhipServer.swift
+++ b/Moblin/Various/Model/ModelWhipServer.swift
@@ -61,7 +61,12 @@ extension Model {
             self.makeToast(title: String(localized: "\(camera) connected"))
             let latency = stream.latencySeconds()
             self.media.addBufferedVideo(cameraId: stream.id, name: camera, latency: latency)
-            self.media.addBufferedAudio(cameraId: stream.id, name: camera, latency: latency)
+            self.media.addBufferedAudio(
+                cameraId: stream.id,
+                name: camera,
+                latency: latency,
+                audioOffset: stream.audioOffsetSeconds()
+            )
         }
     }
 
@@ -102,6 +107,10 @@ extension Model {
             ingests.whip = WhipServer(settings: database.whipServer.clone(), delegate: self)
             ingests.whip?.start()
         }
+    }
+
+    func setWhipStreamAudioOffset(stream: SettingsWhipServerStream) {
+        media.setBufferedAudioOffset(cameraId: stream.id, offset: stream.audioOffsetSeconds())
     }
 }
 

--- a/Moblin/Various/Settings/SettingsIngests.swift
+++ b/Moblin/Various/Settings/SettingsIngests.swift
@@ -8,12 +8,14 @@ class SettingsRtmpServerStream: Codable, Identifiable, ObservableObject, Named {
     @Published var name: String = baseName
     @Published var streamKey: String = ""
     @Published var latency: Int32 = defaultRtmpLatency
+    @Published var audioOffset: Int32 = 0
 
     enum CodingKeys: CodingKey {
         case id
         case name
         case streamKey
         case latency
+        case audioOffset
     }
 
     func encode(to encoder: any Encoder) throws {
@@ -22,6 +24,7 @@ class SettingsRtmpServerStream: Codable, Identifiable, ObservableObject, Named {
         try container.encode(.name, name)
         try container.encode(.streamKey, streamKey)
         try container.encode(.latency, latency)
+        try container.encode(.audioOffset, audioOffset)
     }
 
     init() {}
@@ -32,6 +35,7 @@ class SettingsRtmpServerStream: Codable, Identifiable, ObservableObject, Named {
         name = container.decode(.name, String.self, Self.baseName)
         streamKey = container.decode(.streamKey, String.self, "")
         latency = container.decode(.latency, Int32.self, defaultRtmpLatency)
+        audioOffset = container.decode(.audioOffset, Int32.self, 0)
     }
 
     func camera() -> String {
@@ -42,12 +46,17 @@ class SettingsRtmpServerStream: Codable, Identifiable, ObservableObject, Named {
         Double(latency) / 1000
     }
 
+    func audioOffsetSeconds() -> Double {
+        Double(audioOffset) / 1000
+    }
+
     func clone() -> SettingsRtmpServerStream {
         let new = SettingsRtmpServerStream()
         new.id = id
         new.name = name
         new.streamKey = streamKey
         new.latency = latency
+        new.audioOffset = audioOffset
         return new
     }
 }
@@ -95,11 +104,13 @@ class SettingsSrtlaServerStream: Codable, Identifiable, ObservableObject, Named 
     var id: UUID = .init()
     @Published var name: String = baseName
     @Published var streamId: String = ""
+    @Published var audioOffset: Int32 = 0
 
     enum CodingKeys: CodingKey {
         case id
         case name
         case streamId
+        case audioOffset
     }
 
     func encode(to encoder: any Encoder) throws {
@@ -107,6 +118,7 @@ class SettingsSrtlaServerStream: Codable, Identifiable, ObservableObject, Named 
         try container.encode(.id, id)
         try container.encode(.name, name)
         try container.encode(.streamId, streamId)
+        try container.encode(.audioOffset, audioOffset)
     }
 
     init() {}
@@ -116,10 +128,15 @@ class SettingsSrtlaServerStream: Codable, Identifiable, ObservableObject, Named 
         id = container.decode(.id, UUID.self, .init())
         name = container.decode(.name, String.self, Self.baseName)
         streamId = container.decode(.streamId, String.self, "")
+        audioOffset = container.decode(.audioOffset, Int32.self, 0)
     }
 
     func camera() -> String {
         srtlaCamera(name: name)
+    }
+
+    func audioOffsetSeconds() -> Double {
+        Double(audioOffset) / 1000
     }
 
     func clone() -> SettingsSrtlaServerStream {
@@ -127,6 +144,7 @@ class SettingsSrtlaServerStream: Codable, Identifiable, ObservableObject, Named 
         new.id = id
         new.name = name
         new.streamId = streamId
+        new.audioOffset = audioOffset
         return new
     }
 }
@@ -186,12 +204,14 @@ class SettingsSrtClientStream: Codable, Identifiable, ObservableObject, Named {
     @Published var name: String = baseName
     @Published var url: String = ""
     @Published var enabled: Bool = false
+    @Published var audioOffset: Int32 = 0
 
     enum CodingKeys: CodingKey {
         case id
         case name
         case url
         case enabled
+        case audioOffset
     }
 
     func encode(to encoder: any Encoder) throws {
@@ -200,6 +220,7 @@ class SettingsSrtClientStream: Codable, Identifiable, ObservableObject, Named {
         try container.encode(.name, name)
         try container.encode(.url, url)
         try container.encode(.enabled, enabled)
+        try container.encode(.audioOffset, audioOffset)
     }
 
     init() {}
@@ -210,10 +231,15 @@ class SettingsSrtClientStream: Codable, Identifiable, ObservableObject, Named {
         name = container.decode(.name, String.self, Self.baseName)
         url = container.decode(.url, String.self, "")
         enabled = container.decode(.enabled, Bool.self, false)
+        audioOffset = container.decode(.audioOffset, Int32.self, 0)
     }
 
     func camera() -> String {
         srtClientCamera(name: name)
+    }
+
+    func audioOffsetSeconds() -> Double {
+        Double(audioOffset) / 1000
     }
 }
 
@@ -243,6 +269,7 @@ class SettingsRistServerStream: Codable, Identifiable, ObservableObject, Named {
     @Published var name: String = baseName
     @Published var virtualDestinationPort: UInt16 = 1
     @Published var latency: Int32 = 2000
+    @Published var audioOffset: Int32 = 0
     var connected: Bool = false
 
     enum CodingKeys: CodingKey {
@@ -250,6 +277,7 @@ class SettingsRistServerStream: Codable, Identifiable, ObservableObject, Named {
         case name
         case virtualDestinationPort
         case latency
+        case audioOffset
     }
 
     func encode(to encoder: any Encoder) throws {
@@ -258,6 +286,7 @@ class SettingsRistServerStream: Codable, Identifiable, ObservableObject, Named {
         try container.encode(.name, name)
         try container.encode(.virtualDestinationPort, virtualDestinationPort)
         try container.encode(.latency, latency)
+        try container.encode(.audioOffset, audioOffset)
     }
 
     init() {}
@@ -268,10 +297,15 @@ class SettingsRistServerStream: Codable, Identifiable, ObservableObject, Named {
         name = container.decode(.name, String.self, Self.baseName)
         virtualDestinationPort = container.decode(.virtualDestinationPort, UInt16.self, 1)
         latency = container.decode(.latency, Int32.self, 2000)
+        audioOffset = container.decode(.audioOffset, Int32.self, 0)
     }
 
     func latencySeconds() -> Double {
         Double(latency) / 1000
+    }
+
+    func audioOffsetSeconds() -> Double {
+        Double(audioOffset) / 1000
     }
 
     func clone() -> SettingsRistServerStream {
@@ -279,6 +313,7 @@ class SettingsRistServerStream: Codable, Identifiable, ObservableObject, Named {
         new.name = name
         new.virtualDestinationPort = virtualDestinationPort
         new.latency = latency
+        new.audioOffset = audioOffset
         return new
     }
 
@@ -413,6 +448,7 @@ class SettingsWhipServerStream: Codable, Identifiable, ObservableObject, Named {
     @Published var streamKey: String = ""
     @Published var latency: Int32 = 100
     @Published var syncTimestamps: Bool = true
+    @Published var audioOffset: Int32 = 0
 
     enum CodingKeys: CodingKey {
         case id
@@ -420,6 +456,7 @@ class SettingsWhipServerStream: Codable, Identifiable, ObservableObject, Named {
         case streamKey
         case latency
         case syncTimestamps
+        case audioOffset
     }
 
     func encode(to encoder: any Encoder) throws {
@@ -429,6 +466,7 @@ class SettingsWhipServerStream: Codable, Identifiable, ObservableObject, Named {
         try container.encode(.streamKey, streamKey)
         try container.encode(.latency, latency)
         try container.encode(.syncTimestamps, syncTimestamps)
+        try container.encode(.audioOffset, audioOffset)
     }
 
     init() {}
@@ -440,6 +478,7 @@ class SettingsWhipServerStream: Codable, Identifiable, ObservableObject, Named {
         streamKey = container.decode(.streamKey, String.self, "")
         latency = container.decode(.latency, Int32.self, 100)
         syncTimestamps = container.decode(.syncTimestamps, Bool.self, true)
+        audioOffset = container.decode(.audioOffset, Int32.self, 0)
     }
 
     func camera() -> String {
@@ -450,12 +489,17 @@ class SettingsWhipServerStream: Codable, Identifiable, ObservableObject, Named {
         Double(latency) / 1000
     }
 
+    func audioOffsetSeconds() -> Double {
+        Double(audioOffset) / 1000
+    }
+
     func clone() -> SettingsWhipServerStream {
         let new = SettingsWhipServerStream()
         new.id = id
         new.name = name
         new.streamKey = streamKey
         new.latency = latency
+        new.audioOffset = audioOffset
         return new
     }
 }
@@ -506,6 +550,7 @@ class SettingsWhepClientStream: Codable, Identifiable, ObservableObject, Named {
     @Published var enabled: Bool = false
     @Published var latency: Int32 = 100
     @Published var syncTimestamps: Bool = true
+    @Published var audioOffset: Int32 = 0
 
     enum CodingKeys: CodingKey {
         case id
@@ -514,10 +559,15 @@ class SettingsWhepClientStream: Codable, Identifiable, ObservableObject, Named {
         case enabled
         case latency
         case syncTimestamps
+        case audioOffset
     }
 
     func latencySeconds() -> Double {
         Double(latency) / 1000
+    }
+
+    func audioOffsetSeconds() -> Double {
+        Double(audioOffset) / 1000
     }
 
     func encode(to encoder: any Encoder) throws {
@@ -528,6 +578,7 @@ class SettingsWhepClientStream: Codable, Identifiable, ObservableObject, Named {
         try container.encode(.enabled, enabled)
         try container.encode(.latency, latency)
         try container.encode(.syncTimestamps, syncTimestamps)
+        try container.encode(.audioOffset, audioOffset)
     }
 
     init() {}
@@ -540,6 +591,7 @@ class SettingsWhepClientStream: Codable, Identifiable, ObservableObject, Named {
         enabled = container.decode(.enabled, Bool.self, false)
         latency = container.decode(.latency, Int32.self, 100)
         syncTimestamps = container.decode(.syncTimestamps, Bool.self, true)
+        audioOffset = container.decode(.audioOffset, Int32.self, 0)
     }
 
     func camera() -> String {

--- a/Moblin/View/Settings/Ingests/RistServer/RistServerStreamSettingsView.swift
+++ b/Moblin/View/Settings/Ingests/RistServer/RistServerStreamSettingsView.swift
@@ -22,6 +22,13 @@ struct RistServerStreamSettingsView: View {
         stream.latency = latency
     }
 
+    private var audioOffsetBinding: Binding<Double> {
+        Binding(
+            get: { Double(stream.audioOffset) },
+            set: { stream.audioOffset = Int32($0.rounded()) }
+        )
+    }
+
     var body: some View {
         NavigationLink {
             Form {
@@ -56,6 +63,21 @@ struct RistServerStreamSettingsView: View {
                     .disabled(ristServer.enabled)
                 } footer: {
                     Text("The higher, the lower risk of stuttering.")
+                }
+                Section {
+                    VStack(alignment: .leading) {
+                        Text("Audio offset")
+                        HStack {
+                            Slider(value: audioOffsetBinding, in: -2000 ... 2000, step: 10)
+                                .onChange(of: stream.audioOffset) { _ in
+                                    model.setRistStreamAudioOffset(stream: stream)
+                                }
+                            Text("\(stream.audioOffset) ms")
+                                .frame(width: 65)
+                        }
+                    }
+                } footer: {
+                    Text("Adjust to fix audio/video sync. Positive delays audio, negative advances it.")
                 }
                 Section {
                     UrlsView(

--- a/Moblin/View/Settings/Ingests/RistServer/RistServerStreamSettingsView.swift
+++ b/Moblin/View/Settings/Ingests/RistServer/RistServerStreamSettingsView.swift
@@ -20,6 +20,11 @@ struct RistServerStreamSettingsView: View {
             return
         }
         stream.latency = latency
+        stream.audioOffset = max(stream.audioOffset, -stream.latency)
+    }
+
+    private var audioOffsetMinMs: Double {
+        max(-2000, -Double(stream.latency))
     }
 
     private var audioOffsetBinding: Binding<Double> {
@@ -68,7 +73,7 @@ struct RistServerStreamSettingsView: View {
                     VStack(alignment: .leading) {
                         Text("Audio offset")
                         HStack {
-                            Slider(value: audioOffsetBinding, in: -2000 ... 2000, step: 10)
+                            Slider(value: audioOffsetBinding, in: audioOffsetMinMs ... 2000, step: 10)
                                 .onChange(of: stream.audioOffset) { _ in
                                     model.setRistStreamAudioOffset(stream: stream)
                                 }

--- a/Moblin/View/Settings/Ingests/RtmpServer/RtmpServerStreamSettingsView.swift
+++ b/Moblin/View/Settings/Ingests/RtmpServer/RtmpServerStreamSettingsView.swift
@@ -46,6 +46,13 @@ struct RtmpServerStreamSettingsView: View {
         stream.latency = latency
     }
 
+    private var audioOffsetBinding: Binding<Double> {
+        Binding(
+            get: { Double(stream.audioOffset) },
+            set: { stream.audioOffset = Int32($0.rounded()) }
+        )
+    }
+
     var body: some View {
         NavigationLink {
             Form {
@@ -75,6 +82,21 @@ struct RtmpServerStreamSettingsView: View {
                     .disabled(model.rtmpServerEnabled())
                 } footer: {
                     Text("The higher, the lower risk of stuttering.")
+                }
+                Section {
+                    VStack(alignment: .leading) {
+                        Text("Audio offset")
+                        HStack {
+                            Slider(value: audioOffsetBinding, in: -2000 ... 2000, step: 10)
+                                .onChange(of: stream.audioOffset) { _ in
+                                    model.setRtmpStreamAudioOffset(stream: stream)
+                                }
+                            Text("\(stream.audioOffset) ms")
+                                .frame(width: 65)
+                        }
+                    }
+                } footer: {
+                    Text("Adjust to fix audio/video sync. Positive delays audio, negative advances it.")
                 }
                 Section {
                     UrlsView(

--- a/Moblin/View/Settings/Ingests/RtmpServer/RtmpServerStreamSettingsView.swift
+++ b/Moblin/View/Settings/Ingests/RtmpServer/RtmpServerStreamSettingsView.swift
@@ -44,6 +44,11 @@ struct RtmpServerStreamSettingsView: View {
             return
         }
         stream.latency = latency
+        stream.audioOffset = max(stream.audioOffset, -stream.latency)
+    }
+
+    private var audioOffsetMinMs: Double {
+        max(-2000, -Double(stream.latency))
     }
 
     private var audioOffsetBinding: Binding<Double> {
@@ -87,7 +92,7 @@ struct RtmpServerStreamSettingsView: View {
                     VStack(alignment: .leading) {
                         Text("Audio offset")
                         HStack {
-                            Slider(value: audioOffsetBinding, in: -2000 ... 2000, step: 10)
+                            Slider(value: audioOffsetBinding, in: audioOffsetMinMs ... 2000, step: 10)
                                 .onChange(of: stream.audioOffset) { _ in
                                     model.setRtmpStreamAudioOffset(stream: stream)
                                 }

--- a/Moblin/View/Settings/Ingests/SrtClient/SrtClientStreamSettingsView.swift
+++ b/Moblin/View/Settings/Ingests/SrtClient/SrtClientStreamSettingsView.swift
@@ -5,6 +5,13 @@ struct SrtClientStreamSettingsView: View {
     @ObservedObject var srtClient: SettingsSrtClient
     @ObservedObject var stream: SettingsSrtClientStream
 
+    private var audioOffsetBinding: Binding<Double> {
+        Binding(
+            get: { Double(stream.audioOffset) },
+            set: { stream.audioOffset = Int32($0.rounded()) }
+        )
+    }
+
     var body: some View {
         NavigationLink {
             Form {
@@ -31,6 +38,21 @@ struct SrtClientStreamSettingsView: View {
                     } label: {
                         TextItemLocalizedView(name: "URL", value: stream.url, sensitive: true)
                     }
+                }
+                Section {
+                    VStack(alignment: .leading) {
+                        Text("Audio offset")
+                        HStack {
+                            Slider(value: audioOffsetBinding, in: -2000 ... 2000, step: 10)
+                                .onChange(of: stream.audioOffset) { _ in
+                                    model.setSrtClientStreamAudioOffset(stream: stream)
+                                }
+                            Text("\(stream.audioOffset) ms")
+                                .frame(width: 65)
+                        }
+                    }
+                } footer: {
+                    Text("Adjust to fix audio/video sync. Positive delays audio, negative advances it.")
                 }
             }
             .navigationTitle("Stream")

--- a/Moblin/View/Settings/Ingests/SrtClient/SrtClientStreamSettingsView.swift
+++ b/Moblin/View/Settings/Ingests/SrtClient/SrtClientStreamSettingsView.swift
@@ -43,7 +43,7 @@ struct SrtClientStreamSettingsView: View {
                     VStack(alignment: .leading) {
                         Text("Audio offset")
                         HStack {
-                            Slider(value: audioOffsetBinding, in: -2000 ... 2000, step: 10)
+                            Slider(value: audioOffsetBinding, in: -500 ... 2000, step: 10)
                                 .onChange(of: stream.audioOffset) { _ in
                                     model.setSrtClientStreamAudioOffset(stream: stream)
                                 }

--- a/Moblin/View/Settings/Ingests/SrtlaServer/SrtlaServerStreamSettingsView.swift
+++ b/Moblin/View/Settings/Ingests/SrtlaServer/SrtlaServerStreamSettingsView.swift
@@ -37,6 +37,13 @@ struct SrtlaServerStreamSettingsView: View {
         return url
     }
 
+    private var audioOffsetBinding: Binding<Double> {
+        Binding(
+            get: { Double(stream.audioOffset) },
+            set: { stream.audioOffset = Int32($0.rounded()) }
+        )
+    }
+
     var body: some View {
         NavigationLink {
             Form {
@@ -53,6 +60,21 @@ struct SrtlaServerStreamSettingsView: View {
                     .disabled(srtlaServer.enabled)
                 } footer: {
                     Text("The stream name is shown in the list of cameras in scene settings.")
+                }
+                Section {
+                    VStack(alignment: .leading) {
+                        Text("Audio offset")
+                        HStack {
+                            Slider(value: audioOffsetBinding, in: -2000 ... 2000, step: 10)
+                                .onChange(of: stream.audioOffset) { _ in
+                                    model.setSrtlaStreamAudioOffset(stream: stream)
+                                }
+                            Text("\(stream.audioOffset) ms")
+                                .frame(width: 65)
+                        }
+                    }
+                } footer: {
+                    Text("Adjust to fix audio/video sync. Positive delays audio, negative advances it.")
                 }
                 Section {
                     UrlsView(

--- a/Moblin/View/Settings/Ingests/SrtlaServer/SrtlaServerStreamSettingsView.swift
+++ b/Moblin/View/Settings/Ingests/SrtlaServer/SrtlaServerStreamSettingsView.swift
@@ -65,7 +65,7 @@ struct SrtlaServerStreamSettingsView: View {
                     VStack(alignment: .leading) {
                         Text("Audio offset")
                         HStack {
-                            Slider(value: audioOffsetBinding, in: -2000 ... 2000, step: 10)
+                            Slider(value: audioOffsetBinding, in: -500 ... 2000, step: 10)
                                 .onChange(of: stream.audioOffset) { _ in
                                     model.setSrtlaStreamAudioOffset(stream: stream)
                                 }

--- a/Moblin/View/Settings/Ingests/WhepClient/WhepClientStreamSettingsView.swift
+++ b/Moblin/View/Settings/Ingests/WhepClient/WhepClientStreamSettingsView.swift
@@ -5,6 +5,10 @@ struct WhepClientStreamSettingsView: View {
     @ObservedObject var whepClient: SettingsWhepClient
     @ObservedObject var stream: SettingsWhepClientStream
 
+    private var audioOffsetMinMs: Double {
+        max(-2000, -Double(stream.latency))
+    }
+
     private var audioOffsetBinding: Binding<Double> {
         Binding(
             get: { Double(stream.audioOffset) },
@@ -43,6 +47,7 @@ struct WhepClientStreamSettingsView: View {
                                 return
                             }
                             stream.latency = latency
+                            stream.audioOffset = max(stream.audioOffset, -stream.latency)
                             model.reloadWhepClient()
                         },
                         footers: [String(localized: "5 or more milliseconds. 100 ms by default.")],
@@ -64,7 +69,7 @@ struct WhepClientStreamSettingsView: View {
                     VStack(alignment: .leading) {
                         Text("Audio offset")
                         HStack {
-                            Slider(value: audioOffsetBinding, in: -2000 ... 2000, step: 10)
+                            Slider(value: audioOffsetBinding, in: audioOffsetMinMs ... 2000, step: 10)
                                 .onChange(of: stream.audioOffset) { _ in
                                     model.setWhepStreamAudioOffset(stream: stream)
                                 }

--- a/Moblin/View/Settings/Ingests/WhepClient/WhepClientStreamSettingsView.swift
+++ b/Moblin/View/Settings/Ingests/WhepClient/WhepClientStreamSettingsView.swift
@@ -5,6 +5,13 @@ struct WhepClientStreamSettingsView: View {
     @ObservedObject var whepClient: SettingsWhepClient
     @ObservedObject var stream: SettingsWhepClientStream
 
+    private var audioOffsetBinding: Binding<Double> {
+        Binding(
+            get: { Double(stream.audioOffset) },
+            set: { stream.audioOffset = Int32($0.rounded()) }
+        )
+    }
+
     var body: some View {
         NavigationLink {
             Form {
@@ -52,6 +59,21 @@ struct WhepClientStreamSettingsView: View {
                             model.reloadWhepClient()
                         }
                         .disabled(stream.enabled)
+                }
+                Section {
+                    VStack(alignment: .leading) {
+                        Text("Audio offset")
+                        HStack {
+                            Slider(value: audioOffsetBinding, in: -2000 ... 2000, step: 10)
+                                .onChange(of: stream.audioOffset) { _ in
+                                    model.setWhepStreamAudioOffset(stream: stream)
+                                }
+                            Text("\(stream.audioOffset) ms")
+                                .frame(width: 65)
+                        }
+                    }
+                } footer: {
+                    Text("Adjust to fix audio/video sync. Positive delays audio, negative advances it.")
                 }
             }
             .navigationTitle("Stream")

--- a/Moblin/View/Settings/Ingests/WhipServer/WhipServerStreamSettingsView.swift
+++ b/Moblin/View/Settings/Ingests/WhipServer/WhipServerStreamSettingsView.swift
@@ -29,6 +29,13 @@ struct WhipServerStreamSettingsView: View {
         stream.latency = latency
     }
 
+    private var audioOffsetBinding: Binding<Double> {
+        Binding(
+            get: { Double(stream.audioOffset) },
+            set: { stream.audioOffset = Int32($0.rounded()) }
+        )
+    }
+
     var body: some View {
         NavigationLink {
             Form {
@@ -62,6 +69,21 @@ struct WhipServerStreamSettingsView: View {
                 Section {
                     Toggle("Sync timestamps", isOn: $stream.syncTimestamps)
                         .disabled(whipServer.enabled)
+                }
+                Section {
+                    VStack(alignment: .leading) {
+                        Text("Audio offset")
+                        HStack {
+                            Slider(value: audioOffsetBinding, in: -2000 ... 2000, step: 10)
+                                .onChange(of: stream.audioOffset) { _ in
+                                    model.setWhipStreamAudioOffset(stream: stream)
+                                }
+                            Text("\(stream.audioOffset) ms")
+                                .frame(width: 65)
+                        }
+                    }
+                } footer: {
+                    Text("Adjust to fix audio/video sync. Positive delays audio, negative advances it.")
                 }
                 Section {
                     UrlsView(

--- a/Moblin/View/Settings/Ingests/WhipServer/WhipServerStreamSettingsView.swift
+++ b/Moblin/View/Settings/Ingests/WhipServer/WhipServerStreamSettingsView.swift
@@ -27,6 +27,11 @@ struct WhipServerStreamSettingsView: View {
             return
         }
         stream.latency = latency
+        stream.audioOffset = max(stream.audioOffset, -stream.latency)
+    }
+
+    private var audioOffsetMinMs: Double {
+        max(-2000, -Double(stream.latency))
     }
 
     private var audioOffsetBinding: Binding<Double> {
@@ -74,7 +79,7 @@ struct WhipServerStreamSettingsView: View {
                     VStack(alignment: .leading) {
                         Text("Audio offset")
                         HStack {
-                            Slider(value: audioOffsetBinding, in: -2000 ... 2000, step: 10)
+                            Slider(value: audioOffsetBinding, in: audioOffsetMinMs ... 2000, step: 10)
                                 .onChange(of: stream.audioOffset) { _ in
                                     model.setWhipStreamAudioOffset(stream: stream)
                                 }


### PR DESCRIPTION
Adds a -2000..+2000 ms audio offset slider to RTMP, SRTLA, RIST, SRT client, WHIP, and WHEP stream settings. The offset is applied as a static correction on top of the DriftTracker in BufferedAudio, so automatic sync still works while the user can nudge audio early or late to fix A/V async.