### PR TITLE
feat: persistently save and manage multiple Wi-Fi credentials for DJI…

### DIFF
--- a/Moblin/Various/Settings/Settings.swift
+++ b/Moblin/Various/Settings/Settings.swift
@@ -1123,6 +1123,7 @@ class Database: Codable, ObservableObject {
     var blackSharkCoolerDevices: SettingsBlackSharkCoolerDevices = .init()
     var remoteSceneId: UUID?
     @Published var sceneNumericInput: Bool = false
+    @Published var savedWifiNetworks: [String: String] = [:]
     var goPro: SettingsGoPro = .init()
     var replay: SettingsReplay = .init()
     var portraitVideoOffsetFromTop: Double = 0.0
@@ -1260,6 +1261,7 @@ class Database: Codable, ObservableObject {
         case talkBack
         case gimbal
         case scoreboardSizeMigrated
+        case savedWifiNetworks
     }
 
     func encode(to encoder: any Encoder) throws {
@@ -1343,6 +1345,7 @@ class Database: Codable, ObservableObject {
         try container.encode(.talkBack, talkback)
         try container.encode(.gimbal, gimbal)
         try container.encode(.scoreboardSizeMigrated, scoreboardSizeMigrated)
+        try container.encode(.savedWifiNetworks, savedWifiNetworks)
     }
 
     init() {}
@@ -1476,6 +1479,7 @@ class Database: Codable, ObservableObject {
         talkback = container.decode(.talkBack, SettingsTalkback.self, .init())
         gimbal = container.decode(.gimbal, SettingsGimbal.self, .init())
         scoreboardSizeMigrated = container.decode(.scoreboardSizeMigrated, Bool.self, false)
+        savedWifiNetworks = container.decode(.savedWifiNetworks, [String: String].self, [:])
         if !scoreboardSizeMigrated {
             for widget in widgets where widget.type == .scoreboard {
                 for scene in scenes {

--- a/Moblin/View/Settings/DjiDevices/DjiDeviceSettingsView.swift
+++ b/Moblin/View/Settings/DjiDevices/DjiDeviceSettingsView.swift
@@ -71,53 +71,109 @@ private struct DjiDeviceSelectDeviceSettingsView: View {
 }
 
 private struct DjiDeviceWiFiSettingsView: View {
+    @EnvironmentObject var model: Model
     @ObservedObject var device: SettingsDjiDevice
 
     var body: some View {
-        Section {
-            NavigationLink {
-                TextEditView(
-                    title: String(localized: "SSID"),
-                    value: device.wifiSsid,
-                    onSubmit: {
-                        device.wifiSsid = $0
-                    }
-                )
-            } label: {
-                TextItemLocalizedView(name: "SSID", value: device.wifiSsid)
-            }
-            .disabled(device.isStarted)
-            NavigationLink {
-                TextEditView(
-                    title: String(localized: "Password"),
-                    value: device.wifiPassword,
-                    onSubmit: {
-                        device.wifiPassword = $0
-                    }
-                )
-            } label: {
-                TextItemLocalizedView(name: "Password", value: device.wifiPassword, sensitive: true)
-            }
-            .disabled(device.isStarted)
-            if device.wifiSsid.isEmpty {
-                Text("⚠️ Enter the SSID of the network the DJI device should connect to.")
-            }
-        } header: {
-            Text("WiFi")
-        } footer: {
-            Text("The DJI device will connect to and stream RTMP over this WiFi.")
-        }
-        .onAppear {
-            NEHotspotNetwork.fetchCurrent(completionHandler: { network in
-                guard let ssid = network?.ssid else {
-                    return
+        Group {
+            Section {
+                NavigationLink {
+                    TextEditView(
+                        title: String(localized: "SSID"),
+                        value: device.wifiSsid,
+                        onSubmit: {
+                            device.wifiSsid = $0
+                            if let savedPassword = model.database.savedWifiNetworks[$0] {
+                                device.wifiPassword = savedPassword
+                            } else {
+                                if !device.wifiPassword.isEmpty {
+                                    model.database.savedWifiNetworks[$0] = device.wifiPassword
+                                    model.storeSettings()
+                                }
+                            }
+                        }
+                    )
+                } label: {
+                    TextItemLocalizedView(name: "SSID", value: device.wifiSsid)
                 }
-                DispatchQueue.main.async {
-                    if device.wifiSsid.isEmpty {
-                        device.wifiSsid = ssid
+                .disabled(device.isStarted)
+                NavigationLink {
+                    TextEditView(
+                        title: String(localized: "Password"),
+                        value: device.wifiPassword,
+                        onSubmit: {
+                            device.wifiPassword = $0
+                            if !device.wifiSsid.isEmpty {
+                                model.database.savedWifiNetworks[device.wifiSsid] = $0
+                                model.storeSettings()
+                            }
+                        }
+                    )
+                } label: {
+                    TextItemLocalizedView(name: "Password", value: device.wifiPassword, sensitive: true)
+                }
+                .disabled(device.isStarted)
+                if device.wifiSsid.isEmpty {
+                    Text("⚠️ Enter the SSID of the network the DJI device should connect to.")
+                }
+            } header: {
+                Text("WiFi")
+            } footer: {
+                Text("The DJI device will connect to and stream RTMP over this WiFi.")
+            }
+            .onAppear {
+                NEHotspotNetwork.fetchCurrent(completionHandler: { network in
+                    guard let ssid = network?.ssid else {
+                        return
+                    }
+                    DispatchQueue.main.async {
+                        if device.wifiSsid.isEmpty {
+                            device.wifiSsid = ssid
+                            if let savedPassword = model.database.savedWifiNetworks[ssid] {
+                                device.wifiPassword = savedPassword
+                            }
+                        }
+                    }
+                })
+                if !device.wifiSsid.isEmpty && device.wifiPassword.isEmpty {
+                    if let savedPassword = model.database.savedWifiNetworks[device.wifiSsid] {
+                        device.wifiPassword = savedPassword
                     }
                 }
-            })
+            }
+
+            if !model.database.savedWifiNetworks.isEmpty {
+                Section {
+                    ForEach(model.database.savedWifiNetworks.keys.sorted(), id: \.self) { ssid in
+                        Button {
+                            device.wifiSsid = ssid
+                            device.wifiPassword = model.database.savedWifiNetworks[ssid] ?? ""
+                        } label: {
+                            HStack {
+                                Text(ssid)
+                                    .foregroundColor(.primary)
+                                Spacer()
+                                if device.wifiSsid == ssid {
+                                    Image(systemName: "checkmark")
+                                        .foregroundColor(.blue)
+                                }
+                            }
+                        }
+                        .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+                            Button(role: .destructive) {
+                                model.database.savedWifiNetworks.removeValue(forKey: ssid)
+                                model.storeSettings()
+                            } label: {
+                                Label("Delete", systemImage: "trash")
+                            }
+                        }
+                    }
+                } header: {
+                    Text("Saved Networks")
+                } footer: {
+                    Text("Tap a network to select it, or swipe left to delete.")
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Hi Erik,

Currently, the DJI device settings page only stores a single Wi-Fi SSID and password per device profile. Every time a user switches location (e.g., streaming between home Wi-Fi, office Wi-Fi, or cellular hotspot), they must manually re-type both the SSID and the password.

This PR implements a persistent Wi-Fi credentials memory feature directly in Moblin settings:
1. Added a persistent `savedWifiNetworks` dictionary (`[String: String]`) to the database.
2. SSID and password entries are automatically saved/updated in this dictionary upon submission.
3. Automatically auto-fills the password if a typed SSID matches a previously saved network.
4. Created a "Saved Networks" list section below the WiFi settings on the DJI Device page. Tapping any saved network instantly populates both fields, and users can swipe left to delete any saved network.

Thanks!