### PR TITLE
add {windKmh} variable to display wind speed in km/h

### DIFF
--- a/Common/Various/CommonUtils.swift
+++ b/Common/Various/CommonUtils.swift
@@ -203,6 +203,18 @@ func formatWindAndGustSpeed(speed: Measurement<UnitSpeed>, gust: Measurement<Uni
     return "\(speed) (\(gust)) \(unit.symbol)"
 }
 
+func formatWindSpeedKmh(speed: Measurement<UnitSpeed>) -> String {
+    let unit: UnitSpeed = .kilometersPerHour
+    return createWindSpeedFormatter().string(from: speed.converted(to: unit))
+}
+
+func formatWindAndGustSpeedKmh(speed: Measurement<UnitSpeed>, gust: Measurement<UnitSpeed>) -> String {
+    let unit: UnitSpeed = .kilometersPerHour
+    let speed = Int(speed.converted(to: unit).value)
+    let gust = Int(gust.converted(to: unit).value)
+    return "\(speed) (\(gust)) \(unit.symbol)"
+}
+
 func formatPace(speed: Double) -> String {
     let unit: UnitLength = Locale.current.measurementSystem == .metric ? .kilometers : .miles
     let pace: String

--- a/Moblin/VideoEffects/Text/TextEffectFormatter.swift
+++ b/Moblin/VideoEffects/Text/TextEffectFormatter.swift
@@ -127,6 +127,8 @@ class TextEffectFormatter {
                 formatFeelsLikeTemperature(stats: stats)
             case .wind:
                 formatWind(stats: stats)
+            case .windKmh:
+                formatWindKmh(stats: stats)
             case .country:
                 formatCountry(stats: stats)
             case .countryFlag:
@@ -317,6 +319,18 @@ class TextEffectFormatter {
                 appendTextPart(value: formatWindAndGustSpeed(speed: windSpeed, gust: windGust))
             } else {
                 appendTextPart(value: formatWindSpeed(speed: windSpeed))
+            }
+        } else {
+            appendTextPart(value: "-")
+        }
+    }
+
+    private func formatWindKmh(stats: TextEffectStats) {
+        if let windSpeed = stats.windSpeed {
+            if let windGust = stats.windGust {
+                appendTextPart(value: formatWindAndGustSpeedKmh(speed: windSpeed, gust: windGust))
+            } else {
+                appendTextPart(value: formatWindSpeedKmh(speed: windSpeed))
             }
         } else {
             appendTextPart(value: "-")

--- a/Moblin/VideoEffects/Text/TextFormatStringLoader.swift
+++ b/Moblin/VideoEffects/Text/TextFormatStringLoader.swift
@@ -24,6 +24,7 @@ enum TextFormatPart: Equatable {
     case temperature
     case feelsLikeTemperature
     case wind
+    case windKmh
     case country
     case countryFlag
     case state
@@ -113,6 +114,8 @@ class TextFormatLoader {
                     loadItem(part: .feelsLikeTemperature, offsetBy: 22)
                 } else if formatFromIndex.hasPrefix("{wind}") {
                     loadItem(part: .wind, offsetBy: 6)
+                } else if formatFromIndex.hasPrefix("{windkmh}") {
+                    loadItem(part: .windKmh, offsetBy: 9)
                 } else if formatFromIndex.hasPrefix("{country}") {
                     loadItem(part: .country, offsetBy: 9)
                 } else if formatFromIndex.hasPrefix("{countryflag}") {
@@ -316,6 +319,8 @@ extension [TextFormatPart] {
         } else if contains(.feelsLikeTemperature) {
             return true
         } else if contains(.wind) {
+            return true
+        } else if contains(.windKmh) {
             return true
         }
         return false

--- a/Moblin/View/Settings/Scenes/Widgets/Widget/Text/WidgetTextSettingsView.swift
+++ b/Moblin/View/Settings/Scenes/Widgets/Widget/Text/WidgetTextSettingsView.swift
@@ -786,6 +786,11 @@ private struct WeatherVariablesView: View {
                         description: String(localized: "Show wind"),
                         text: $value
                     )
+                    VariableView(
+                        title: "{windKmh}",
+                        description: String(localized: "Show wind in km/h"),
+                        text: $value
+                    )
                 } footer: {
                     VStack(alignment: .leading) {
                         let image = Image(systemName: "apple.logo")


### PR DESCRIPTION
Hi Erik,

Currently, the `{wind}` text widget placeholder formats the wind speed using the default system metric, which defaults to meters per second (`m/s`) for metric systems. However, in many metric regions (like Brazil and parts of Europe), users are much more accustomed to reading wind speeds in kilometers per hour (`km/h`).

This PR adds a new `{windKmh}` text widget placeholder that explicitly formats and displays the wind speed (and wind gust) in `km/h`.

### Changes:
1. Added `formatWindSpeedKmh` and `formatWindAndGustSpeedKmh` in `CommonUtils.swift` to specifically output km/h.
2. Added the `.windKmh` case and `{windKmh}` parsing logic in `TextFormatStringLoader.swift` and `TextEffectFormatter.swift`.
3. Documented `{windKmh}` in the text widget variables help footer in `WidgetTextSettingsView.swift`.

This allows users to keep the original `{wind}` widget format if they prefer `m/s`, while providing a clean alternative for `km/h`.

Thanks!