### PR TITLE
Interactive Widget Overlay (Drag, Drop, and Resize)

### DIFF
--- a/Moblin/Various/Model/Model.swift
+++ b/Moblin/Various/Model/Model.swift
@@ -401,6 +401,8 @@ final class Model: NSObject, ObservableObject, @unchecked Sendable {
     var pendingStreamImportCollisionTitle: String = ""
     @Published var showDrawOnStream = false
     @Published var showLocalOverlays = true
+    @Published var editWidgetsMode = false
+    @Published var selectedWidgetForInteraction: WidgetInScene?
     @Published var showBrowser = false
     @Published var showNavigation = false
     @Published var webBrowserUrl: String = ""
@@ -1155,6 +1157,7 @@ final class Model: NSObject, ObservableObject, @unchecked Sendable {
         bonding.statisticsFormatter.setNetworkInterfaceNames(database.networkInterfaceNames)
         reloadTeslaVehicle()
         updateQuickButtonStates()
+        editWidgetsMode = database.quickButtons.first(where: { $0.type == .editWidgets })?.isOn ?? false
         setQuickButton(type: .blurFaces, isOn: database.face.blurFaces)
         setQuickButton(type: .blurText, isOn: database.face.blurText)
         setQuickButton(type: .privacy, isOn: database.face.blurBackground)

--- a/Moblin/Various/Model/ModelScene.swift
+++ b/Moblin/Various/Model/ModelScene.swift
@@ -1783,4 +1783,77 @@ extension Model {
         })
         startGForceManager()
     }
+
+    func updateWidgetLayoutDirectly(widgetId: UUID, sceneWidget: SettingsSceneWidget) {
+        // Trigger a UI redraw so InteractiveWidgetOverlayView moves the blue selection borders in real-time
+        objectWillChange.send()
+
+        if let effect = imageEffects[widgetId] {
+            effect.setSceneWidget(sceneWidget: sceneWidget.clone())
+        } else if let effect = textEffects[widgetId] {
+            effect.setSceneWidget(sceneWidget: sceneWidget.clone())
+        } else if let effect = browserEffects[widgetId] {
+            if let scene = getSelectedScene() {
+                effect.setSceneWidget(
+                    sceneWidget: sceneWidget.clone(),
+                    crops: findWidgetCrops(scene: scene, sourceWidgetId: widgetId)
+                )
+            }
+        } else if let effect = mapEffects[widgetId] {
+            effect.setSceneWidget(sceneWidget: sceneWidget.clone())
+        } else if let effect = qrCodeEffects[widgetId] {
+            effect.setSceneWidget(sceneWidget: sceneWidget.clone())
+        } else if let effect = alertsEffects[widgetId] {
+            effect.setPosition(x: sceneWidget.layout.x, y: sceneWidget.layout.y)
+        } else if let effect = videoSourceEffects[widgetId] {
+            effect.setSceneWidget(sceneWidget: sceneWidget.clone())
+        } else if let effect = scoreboardEffects[widgetId] {
+            effect.setSceneWidget(sceneWidget: sceneWidget.clone())
+        } else if let effect = vTuberEffects[widgetId] {
+            effect.setSceneWidget(sceneWidget: sceneWidget.clone())
+        } else if let effect = pngTuberEffects[widgetId] {
+            effect.setSceneWidget(sceneWidget: sceneWidget.clone())
+        } else if let effect = snapshotEffects[widgetId] {
+            effect.setSceneWidget(sceneWidget: sceneWidget.clone())
+        } else if let effect = chatEffects[widgetId] {
+            effect.setSceneWidget(sceneWidget: sceneWidget.clone())
+        } else if let effect = chatEmoteComboEffects[widgetId] {
+            effect.setSceneWidget(sceneWidget: sceneWidget.clone())
+        } else if let effect = slideshowEffects[widgetId] {
+            effect.setSceneWidget(sceneWidget: sceneWidget.clone())
+        } else if let effect = wheelOfLuckEffects[widgetId] {
+            effect.setSceneWidget(sceneWidget: sceneWidget.clone())
+        } else if let effect = bingoCardEffects[widgetId] {
+            effect.setSceneWidget(sceneWidget: sceneWidget.clone())
+        } else if let effect = pomodoroTimerEffects[widgetId] {
+            effect.setSceneWidget(sceneWidget: sceneWidget.clone())
+        }
+    }
+
+    func bringWidgetToFront(widgetId: UUID) {
+        guard let scene = getSelectedScene() else { return }
+        if let index = scene.widgets.firstIndex(where: { $0.widgetId == widgetId }) {
+            let sceneWidget = scene.widgets.remove(at: index)
+            scene.widgets.append(sceneWidget)
+            sceneUpdated(attachCamera: false, updateRemoteScene: true)
+        }
+    }
+
+    func sendWidgetToBack(widgetId: UUID) {
+        guard let scene = getSelectedScene() else { return }
+        if let index = scene.widgets.firstIndex(where: { $0.widgetId == widgetId }) {
+            let sceneWidget = scene.widgets.remove(at: index)
+            scene.widgets.insert(sceneWidget, at: 0)
+            sceneUpdated(attachCamera: false, updateRemoteScene: true)
+        }
+    }
+
+    func deleteWidgetFromScene(widgetId: UUID) {
+        guard let scene = getSelectedScene() else { return }
+        if let index = scene.widgets.firstIndex(where: { $0.widgetId == widgetId }) {
+            scene.widgets.remove(at: index)
+            selectedWidgetForInteraction = nil
+            sceneUpdated(attachCamera: false, updateRemoteScene: true)
+        }
+    }
 }

--- a/Moblin/Various/Settings/Settings.swift
+++ b/Moblin/Various/Settings/Settings.swift
@@ -1709,6 +1709,11 @@ private func addMissingQuickButtonsPageOne(database: Database) {
                                  imageOn: "globe",
                                  page: page)
     updateQuickButton(database: database, button: button)
+    button = SettingsQuickButton(type: .editWidgets,
+                                 imageOn: "arrow.up.and.down.and.arrow.left.and.right",
+                                 imageOff: "arrow.up.and.down.and.arrow.left.and.right",
+                                 page: page)
+    updateQuickButton(database: database, button: button)
 }
 
 private func addMissingQuickButtonsPageTwo(database: Database) {

--- a/Moblin/Various/Settings/SettingsQuickButtons.swift
+++ b/Moblin/Various/Settings/SettingsQuickButtons.swift
@@ -66,6 +66,7 @@ enum SettingsQuickButtonType: String, Codable, CaseIterable {
     case macros = "Macros"
     case gimbalTracking = "Gimbal tracking"
     case previewStream = "Preview stream"
+    case editWidgets = "Edit widgets"
 
     init(from decoder: any Decoder) throws {
         var value = try decoder.singleValueContainer().decode(RawValue.self)
@@ -205,6 +206,8 @@ enum SettingsQuickButtonType: String, Codable, CaseIterable {
             String(localized: "Gimbal tracking")
         case .previewStream:
             String(localized: "Preview stream")
+        case .editWidgets:
+            String(localized: "Edit widgets")
         }
     }
 

--- a/Moblin/Various/Settings/SettingsScene.swift
+++ b/Moblin/Various/Settings/SettingsScene.swift
@@ -2619,6 +2619,7 @@ struct SettingsWidgetLayout: Equatable {
     var sizeString: String = "100.0"
     var alignment: SettingsAlignment = .topLeft
     var positioningLock: Bool = false
+    var clickable: Bool = true
 
     mutating func updateXString() {
         xString = String(x)
@@ -2666,6 +2667,7 @@ class SettingsSceneWidget: Codable, Identifiable, Equatable, ObservableObject, @
         case size
         case alignment
         case positioningLock
+        case clickable
         case migrated
         case migrated2
     }
@@ -2681,6 +2683,7 @@ class SettingsSceneWidget: Codable, Identifiable, Equatable, ObservableObject, @
         try container.encode(.size, layout.size)
         try container.encode(.alignment, layout.alignment)
         try container.encode(.positioningLock, layout.positioningLock)
+        try container.encode(.clickable, layout.clickable)
         try container.encode(.migrated, migrated)
         try container.encode(.migrated2, migrated2)
     }
@@ -2703,6 +2706,7 @@ class SettingsSceneWidget: Codable, Identifiable, Equatable, ObservableObject, @
         layout.updateSizeString()
         layout.alignment = container.decode(.alignment, SettingsAlignment.self, .topLeft)
         layout.positioningLock = container.decode(.positioningLock, Bool.self, false)
+        layout.clickable = container.decode(.clickable, Bool.self, true)
         migrated = container.decode(.migrated, Bool.self, false)
         migrated2 = container.decode(.migrated2, Bool.self, false)
     }

--- a/Moblin/View/ControlBar/QuickButton/QuickButtonSceneWidgetsView.swift
+++ b/Moblin/View/ControlBar/QuickButton/QuickButtonSceneWidgetsView.swift
@@ -59,6 +59,25 @@ struct QuickButtonSceneWidgetsView: View {
     var body: some View {
         Form {
             Section {
+                Toggle(isOn: Binding(
+                    get: { model.editWidgetsMode },
+                    set: { value in
+                        model.editWidgetsMode = value
+                        model.setQuickButton(type: .editWidgets, isOn: value)
+                        model.updateQuickButtonStates()
+                    }
+                )) {
+                    IconAndTextView(
+                        image: "arrow.up.and.down.and.arrow.left.and.right",
+                        text: String(localized: "Edit layout on screen"),
+                        longDivider: true
+                    )
+                }
+            } footer: {
+                Text("Turn on to drag and resize widgets directly on the camera preview.")
+            }
+
+            Section {
                 List {
                     ForEach(model.widgetsInCurrentScene(onlyEnabled: false)) { widget in
                         WidgetView(model: model,

--- a/Moblin/View/ControlBar/QuickButtonsView.swift
+++ b/Moblin/View/ControlBar/QuickButtonsView.swift
@@ -301,6 +301,13 @@ struct QuickButtonsInnerView: View {
         model.toggleShowingPanel(type: .widgets, panel: .sceneWidgets)
     }
 
+    private func editWidgetsAction(state: ButtonState) {
+        state.button.isOn.toggle()
+        model.setQuickButton(type: .editWidgets, isOn: state.button.isOn)
+        model.updateQuickButtonStates()
+        model.editWidgetsMode = state.button.isOn
+    }
+
     private func lutsAction() {
         model.toggleShowingPanel(type: .luts, panel: .luts)
         model.updateLutsButtonState()
@@ -714,6 +721,14 @@ struct QuickButtonsInnerView: View {
                                          buttonSize: size)
                         {
                             widgetsAction()
+                        }
+                    case .editWidgets:
+                        QuickButtonImage(model: model,
+                                         quickButtonsSettings: quickButtonsSettings,
+                                         state: state,
+                                         buttonSize: size)
+                        {
+                            editWidgetsAction(state: state)
                         }
                     case .luts:
                         QuickButtonImage(model: model,

--- a/Moblin/View/MainView.swift
+++ b/Moblin/View/MainView.swift
@@ -464,13 +464,17 @@ struct MainView: View {
                             ZStack {
                                 streamView
                                     .onTapGesture(count: 1) {
+                                        guard !model.editWidgetsMode else { return }
                                         handleTapToFocus(metrics: metrics, location: $0)
                                     }
                                     .onLongPressGesture {
+                                        guard !model.editWidgetsMode else { return }
                                         handleLeaveTapToFocus()
                                     }
+                                    .allowsHitTesting(!model.editWidgetsMode)
                                 StreamOverlayTapGridView(camera: model.camera, size: metrics.size)
                                 browserWidgets(streamSize: metrics.size)
+                                InteractiveWidgetOverlayView(model: model, previewSize: metrics.size)
                             }
                             .offset(CGSize(
                                 width: 0,
@@ -490,6 +494,7 @@ struct MainView: View {
                                       width: metrics.size.width)
                         .opacity(model.showLocalOverlays ? 1 : 0)
                 }
+                .allowsHitTesting(!model.editWidgetsMode)
                 if model.showDrawOnStream, model.stream.portrait {
                     DrawOnStreamView(model: model)
                 }
@@ -521,12 +526,14 @@ struct MainView: View {
                         .padding(.top, -7)
                 }
             }
-            .gesture(
+            .simultaneousGesture(
                 MagnificationGesture()
                     .onChanged { amount in
+                        guard !model.editWidgetsMode else { return }
                         model.changeZoomX(amount: Float(amount))
                     }
                     .onEnded { amount in
+                        guard !model.editWidgetsMode else { return }
                         model.commitZoomX(amount: Float(amount))
                     }
             )
@@ -545,13 +552,17 @@ struct MainView: View {
                             ZStack {
                                 streamView
                                     .onTapGesture(count: 1) {
+                                        guard !model.editWidgetsMode else { return }
                                         handleTapToFocus(metrics: metrics, location: $0)
                                     }
                                     .onLongPressGesture {
+                                        guard !model.editWidgetsMode else { return }
                                         handleLeaveTapToFocus()
                                     }
+                                    .allowsHitTesting(!model.editWidgetsMode)
                                 StreamOverlayTapGridView(camera: model.camera, size: metrics.size)
                                 browserWidgets(streamSize: metrics.size)
+                                InteractiveWidgetOverlayView(model: model, previewSize: metrics.size)
                             }
                         }
                         .aspectRatio(streamAspectRatio(), contentMode: .fit)
@@ -567,6 +578,7 @@ struct MainView: View {
                                       width: metrics.size.width)
                         .opacity(model.showLocalOverlays ? 1 : 0)
                 }
+                .allowsHitTesting(!model.editWidgetsMode)
                 if model.showDrawOnStream {
                     DrawOnStreamView(model: model)
                 }
@@ -593,12 +605,14 @@ struct MainView: View {
                         .padding(.trailing, -1)
                 }
             }
-            .gesture(
+            .simultaneousGesture(
                 MagnificationGesture()
                     .onChanged { amount in
+                        guard !model.editWidgetsMode else { return }
                         model.changeZoomX(amount: Float(amount))
                     }
                     .onEnded { amount in
+                        guard !model.editWidgetsMode else { return }
                         model.commitZoomX(amount: Float(amount))
                     }
             )

--- a/Moblin/View/Stream/InteractiveWidgetOverlayView.swift
+++ b/Moblin/View/Stream/InteractiveWidgetOverlayView.swift
@@ -1,0 +1,747 @@
+import SwiftUI
+#if canImport(UIKit)
+import UIKit
+#endif
+
+// MARK: - Interactive Widget Overlay View
+
+// This view overlays the video preview and allows users to select, drag, resize,
+// and manage widgets using touch gestures (tap, drag, pinch).
+//
+// Architecture:
+// - Tap to select/deselect widgets
+// - Single-finger drag to move selected widget
+// - Two-finger pinch to resize selected widget
+// - Corner handles for precise resize
+// - Snapping to edges and center guides with haptic feedback
+// - HUD toolbar for z-ordering, locking, and deletion
+
+struct InteractiveWidgetOverlayView: View {
+    @ObservedObject var model: Model
+    let previewSize: CGSize
+
+    // Drag state
+    @State private var activeDragWidgetId: UUID?
+    @State private var dragStartLayoutX: Double = 0.0
+    @State private var dragStartLayoutY: Double = 0.0
+    @State private var dragStartTranslationX: CGFloat = 0.0
+    @State private var dragStartTranslationY: CGFloat = 0.0
+    @State private var lastDragUpdate: Date = .init()
+
+    // Pinch state
+    @State private var pinchStartSize: Double = 0.0
+    @State private var isPinching: Bool = false
+
+    // Snapping states
+    @State private var activeSnapX: CGFloat?
+    @State private var activeSnapY: CGFloat?
+    @State private var hasHapticedX: Bool = false
+    @State private var hasHapticedY: Bool = false
+
+    // Corner resizing states
+    @State private var activeResizeHandle: String?
+    @State private var resizeStartRect: CGRect = .zero
+    @State private var resizeStartSize: Double = 0.0
+    @State private var resizeStartLayoutX: Double = 0.0
+    @State private var resizeStartLayoutY: Double = 0.0
+
+    private let snapThreshold: CGFloat = 4.0
+
+    // MARK: - Haptic Feedback
+
+    private func triggerHaptic() {
+        #if os(iOS)
+        let generator = UIImpactFeedbackGenerator(style: .light)
+        generator.prepare()
+        generator.impactOccurred()
+        #endif
+    }
+
+    // MARK: - Coordinate Mapping
+
+    private func getVideoBounds() -> CGRect {
+        let streamAspect = model.stream.dimensions().aspectRatio()
+        let previewAspect = previewSize.width / previewSize.height
+
+        var videoWidth: CGFloat
+        var videoHeight: CGFloat
+        var videoX: CGFloat
+        var videoY: CGFloat
+
+        if previewAspect > streamAspect {
+            videoHeight = previewSize.height
+            videoWidth = videoHeight * streamAspect
+            videoX = (previewSize.width - videoWidth) / 2
+            videoY = 0
+        } else {
+            videoWidth = previewSize.width
+            videoHeight = videoWidth / streamAspect
+            videoX = 0
+            videoY = (previewSize.height - videoHeight) / 2
+        }
+
+        return CGRect(x: videoX, y: videoY, width: videoWidth, height: videoHeight)
+    }
+
+    private func getWidgetRect(widgetInScene: WidgetInScene, videoBounds: CGRect) -> CGRect {
+        let layout = widgetInScene.sceneWidget.layout
+        let (widgetWidth, widgetHeight) = getWidgetDimensions(
+            widgetInScene: widgetInScene,
+            videoBounds: videoBounds
+        )
+
+        // Mirror the move logic from EffectUtils.swift
+        var wX: CGFloat
+        var wY: CGFloat
+
+        if layout.alignment.isHorizontalCenter() {
+            wX = videoBounds.minX + (videoBounds.width - widgetWidth) / 2
+        } else if layout.alignment.isLeft() {
+            wX = videoBounds.minX + CGFloat(layout.x / 100.0) * videoBounds.width
+        } else { // Right
+            wX = videoBounds.minX + videoBounds.width - CGFloat(layout.x / 100.0) * videoBounds
+                .width - widgetWidth
+        }
+
+        if layout.alignment.isVerticalCenter() {
+            wY = videoBounds.minY + (videoBounds.height - widgetHeight) / 2
+        } else if layout.alignment.isTop() {
+            wY = videoBounds.minY + CGFloat(layout.y / 100.0) * videoBounds.height
+        } else { // Bottom
+            wY = videoBounds.minY + videoBounds.height - CGFloat(layout.y / 100.0) * videoBounds
+                .height - widgetHeight
+        }
+
+        return CGRect(x: wX, y: wY, width: widgetWidth, height: widgetHeight)
+    }
+
+    private func getWidgetAspectRatio(widget: SettingsWidget) -> CGFloat {
+        switch widget.type {
+        case .image:
+            if let data = model.imageStorage.read(id: widget.id),
+               let img = UIImage(data: data)
+            {
+                return img.size.width / img.size.height
+            }
+            return 1.0
+        case .browser:
+            return CGFloat(max(widget.browser.width, 1)) / CGFloat(max(widget.browser.height, 1))
+        case .videoSource:
+            return 16.0 / 9.0
+        case .text:
+            return 4.0
+        default:
+            return 1.0
+        }
+    }
+
+    // MARK: - Layout Conversion
+
+    /// Convert any alignment mode to topLeft for direct position manipulation during gestures.
+    /// This ensures consistent coordinate math regardless of the widget's original alignment.
+    private func convertToTopLeft(widgetInScene: WidgetInScene, rect: CGRect, videoBounds: CGRect) {
+        var layout = widgetInScene.sceneWidget.layout
+        let currentXPercent = ((rect.minX - videoBounds.minX) / videoBounds.width) * 100.0
+        let currentYPercent = ((rect.minY - videoBounds.minY) / videoBounds.height) * 100.0
+
+        layout.alignment = .topLeft
+        layout.x = max(0.0, Double(currentXPercent))
+        layout.y = max(0.0, Double(currentYPercent))
+        layout.updateXString()
+        layout.updateYString()
+
+        widgetInScene.sceneWidget.layout = layout
+    }
+
+    // MARK: - Snapping Logic
+
+    private func applySnapping(
+        candidateMinX: inout CGFloat,
+        candidateMinY: inout CGFloat,
+        widgetWidth: CGFloat,
+        widgetHeight: CGFloat,
+        videoBounds: CGRect
+    ) {
+        // Vertical snap guides (left, center, right)
+        var snapLineX: CGFloat?
+        let leftDiff = abs(candidateMinX - videoBounds.minX)
+        let centerDiff = abs((candidateMinX + widgetWidth / 2) - videoBounds.midX)
+        let rightDiff = abs((candidateMinX + widgetWidth) - videoBounds.maxX)
+
+        if leftDiff < snapThreshold {
+            candidateMinX = videoBounds.minX
+            snapLineX = videoBounds.minX
+        } else if centerDiff < snapThreshold {
+            candidateMinX = videoBounds.midX - widgetWidth / 2
+            snapLineX = videoBounds.midX
+        } else if rightDiff < snapThreshold {
+            candidateMinX = videoBounds.maxX - widgetWidth
+            snapLineX = videoBounds.maxX
+        }
+
+        // Horizontal snap guides (top, center, bottom)
+        var snapLineY: CGFloat?
+        let topDiff = abs(candidateMinY - videoBounds.minY)
+        let centerVDiff = abs((candidateMinY + widgetHeight / 2) - videoBounds.midY)
+        let bottomDiff = abs((candidateMinY + widgetHeight) - videoBounds.maxY)
+
+        if topDiff < snapThreshold {
+            candidateMinY = videoBounds.minY
+            snapLineY = videoBounds.minY
+        } else if centerVDiff < snapThreshold {
+            candidateMinY = videoBounds.midY - widgetHeight / 2
+            snapLineY = videoBounds.midY
+        } else if bottomDiff < snapThreshold {
+            candidateMinY = videoBounds.maxY - widgetHeight
+            snapLineY = videoBounds.maxY
+        }
+
+        // Haptic feedback on snap engage/disengage
+        if snapLineX != nil {
+            if !hasHapticedX {
+                triggerHaptic()
+                hasHapticedX = true
+            }
+        } else {
+            hasHapticedX = false
+        }
+
+        if snapLineY != nil {
+            if !hasHapticedY {
+                triggerHaptic()
+                hasHapticedY = true
+            }
+        } else {
+            hasHapticedY = false
+        }
+
+        activeSnapX = snapLineX
+        activeSnapY = snapLineY
+    }
+
+    // MARK: - Widget Dimensions Helper
+
+    private func getWidgetDimensions(widgetInScene: WidgetInScene,
+                                     videoBounds: CGRect) -> (CGFloat, CGFloat)
+    {
+        if widgetInScene.widget.type == .text {
+            let fontSize = CGFloat(widgetInScene.widget.text.fontSizeFloat)
+            // The text rendered height is roughly fontSize * scale.
+            let scale = videoBounds.width / 1920.0
+            let estHeight = max(fontSize * scale * 1.2, 24) // Minimum 24pt height
+            let estWidth = max(estHeight * 2.5, 60) // Aspect 2.5:1 width
+            return (estWidth, estHeight)
+        }
+
+        let layout = widgetInScene.sceneWidget.layout
+        let aspect = getWidgetAspectRatio(widget: widgetInScene.widget)
+        let streamAspect = model.stream.dimensions().aspectRatio()
+
+        var widgetWidth: CGFloat
+        var widgetHeight: CGFloat
+        if streamAspect < aspect {
+            widgetWidth = CGFloat(layout.size / 100.0) * videoBounds.width
+            widgetHeight = widgetWidth / aspect
+        } else {
+            widgetHeight = CGFloat(layout.size / 100.0) * videoBounds.height
+            widgetWidth = widgetHeight * aspect
+        }
+        return (widgetWidth, widgetHeight)
+    }
+
+    // MARK: - Corner Resize Handles
+
+    private func cornerHandle(
+        x: CGFloat,
+        y: CGFloat,
+        handle: String,
+        widgetInScene: WidgetInScene,
+        rect: CGRect,
+        videoBounds: CGRect
+    ) -> some View {
+        let handleSize: CGFloat = 12
+        return Circle()
+            .fill(Color.white)
+            .frame(width: handleSize, height: handleSize)
+            .overlay(
+                Circle()
+                    .stroke(Color.black, lineWidth: 1)
+            )
+            .contentShape(Circle().scale(2.0)) // Larger hit area for easier touch
+            .position(x: x, y: y)
+            .highPriorityGesture(
+                DragGesture(minimumDistance: 1, coordinateSpace: .global)
+                    .onChanged { value in
+                        var layout = widgetInScene.sceneWidget.layout
+                        guard !layout.positioningLock else { return }
+
+                        if activeResizeHandle != handle {
+                            activeResizeHandle = handle
+                            convertToTopLeft(
+                                widgetInScene: widgetInScene,
+                                rect: rect,
+                                videoBounds: videoBounds
+                            )
+                            layout = widgetInScene.sceneWidget.layout
+                            resizeStartRect = rect
+                            resizeStartSize = layout.size
+                            resizeStartLayoutX = layout.x
+                            resizeStartLayoutY = layout.y
+                        }
+                        let aspect = getWidgetAspectRatio(widget: widgetInScene.widget)
+                        let streamAspect = model.stream.dimensions().aspectRatio()
+
+                        var newWidth: CGFloat
+                        var newHeight: CGFloat
+
+                        switch handle {
+                        case "bottomRight":
+                            newWidth = max(20, resizeStartRect.width + value.translation.width)
+                            newHeight = max(20, resizeStartRect.height + value.translation.height)
+
+                            let newSize = if streamAspect < aspect {
+                                Double(newWidth / videoBounds.width) * 100.0
+                            } else {
+                                Double(newHeight / videoBounds.height) * 100.0
+                            }
+                            layout.size = newSize.clamped(to: 1 ... 100)
+                            layout.updateSizeString()
+
+                        case "bottomLeft":
+                            newWidth = max(20, resizeStartRect.width - value.translation.width)
+                            newHeight = max(20, resizeStartRect.height + value.translation.height)
+
+                            let newSize = if streamAspect < aspect {
+                                Double(newWidth / videoBounds.width) * 100.0
+                            } else {
+                                Double(newHeight / videoBounds.height) * 100.0
+                            }
+                            layout.size = newSize.clamped(to: 1 ... 100)
+                            layout.updateSizeString()
+                            layout.x = max(
+                                0.0,
+                                Double((resizeStartRect.maxX - newWidth - videoBounds.minX) / videoBounds
+                                    .width) * 100.0
+                            )
+                            layout.updateXString()
+
+                        case "topRight":
+                            newWidth = max(20, resizeStartRect.width + value.translation.width)
+                            newHeight = max(20, resizeStartRect.height - value.translation.height)
+
+                            let newSize = if streamAspect < aspect {
+                                Double(newWidth / videoBounds.width) * 100.0
+                            } else {
+                                Double(newHeight / videoBounds.height) * 100.0
+                            }
+                            layout.size = newSize.clamped(to: 1 ... 100)
+                            layout.updateSizeString()
+                            layout.y = max(
+                                0.0,
+                                Double((resizeStartRect.maxY - newHeight - videoBounds.minY) / videoBounds
+                                    .height) * 100.0
+                            )
+                            layout.updateYString()
+
+                        case "topLeft":
+                            newWidth = max(20, resizeStartRect.width - value.translation.width)
+                            newHeight = max(20, resizeStartRect.height - value.translation.height)
+
+                            let newSize = if streamAspect < aspect {
+                                Double(newWidth / videoBounds.width) * 100.0
+                            } else {
+                                Double(newHeight / videoBounds.height) * 100.0
+                            }
+                            layout.size = newSize.clamped(to: 1 ... 100)
+                            layout.updateSizeString()
+                            layout.x = max(
+                                0.0,
+                                Double((resizeStartRect.maxX - newWidth - videoBounds.minX) / videoBounds
+                                    .width) * 100.0
+                            )
+                            layout.updateXString()
+                            layout.y = max(
+                                0.0,
+                                Double((resizeStartRect.maxY - newHeight - videoBounds.minY) / videoBounds
+                                    .height) * 100.0
+                            )
+                            layout.updateYString()
+
+                        default:
+                            return
+                        }
+
+                        widgetInScene.sceneWidget.layout = layout
+                        model.updateWidgetLayoutDirectly(
+                            widgetId: widgetInScene.widget.id,
+                            sceneWidget: widgetInScene.sceneWidget
+                        )
+                    }
+                    .onEnded { _ in
+                        activeResizeHandle = nil
+                        model.sceneUpdated(attachCamera: false, updateRemoteScene: true)
+                    }
+            )
+    }
+
+    // MARK: - HUD Toolbar
+
+    private func hudToolbar(widgetInScene: WidgetInScene, rect: CGRect) -> some View {
+        let isLocked = widgetInScene.sceneWidget.layout.positioningLock
+        let toolbarHeight: CGFloat = 38
+
+        let xPos = rect.midX
+        let yPos = rect
+            .minY < 60 ? (rect.maxY + toolbarHeight / 2 + 12) : (rect.minY - toolbarHeight / 2 - 12)
+
+        return HStack(spacing: 12) {
+            Button(action: {
+                triggerHaptic()
+                model.objectWillChange.send()
+                widgetInScene.sceneWidget.layout.positioningLock.toggle()
+                model.storeSettings()
+                model.sceneUpdated(attachCamera: false, updateRemoteScene: true)
+            }, label: {
+                Image(systemName: isLocked ? "lock.fill" : "lock.open.fill")
+                    .font(.system(size: 14, weight: .bold))
+                    .foregroundColor(isLocked ? .red : .white)
+            })
+        }
+        .padding(.horizontal, 14)
+        .frame(height: toolbarHeight)
+        .background(Color.black.opacity(0.85))
+        .cornerRadius(8)
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(Color.white.opacity(0.15), lineWidth: 1)
+        )
+        .shadow(color: Color.black.opacity(0.4), radius: 6, x: 0, y: 3)
+        .position(x: xPos, y: yPos)
+    }
+
+    // MARK: - Widget Item View
+
+    @ViewBuilder
+    private func widgetItemView(widgetInScene: WidgetInScene, rect: CGRect,
+                                videoBounds: CGRect) -> some View
+    {
+        let isSelected = model.selectedWidgetForInteraction?.id == widgetInScene.id
+        let isClickable = widgetInScene.sceneWidget.layout.clickable
+        let isLocked = widgetInScene.sceneWidget.layout.positioningLock
+        let isEnabled = widgetInScene.widget.enabled
+
+        // Widget bounding box with visual feedback
+        ZStack {
+            // Transparent fill covering the minimum 44x44 touch area
+            Color.black.opacity(0.001)
+
+            // Selection outline and content sized to the actual widget rect
+            ZStack {
+                if isSelected {
+                    if widgetInScene.widget.hasSize() {
+                        Rectangle()
+                            .stroke(
+                                !isEnabled ? Color.white :
+                                    (!isClickable ? Color.gray.opacity(0.4) : Color.white),
+                                style: StrokeStyle(lineWidth: 1.5)
+                            )
+                            .background(Color.white.opacity(0.25))
+                    } else {
+                        // Show a move icon in the center for select / drag when it has no layout size setting
+                        Image(systemName: "arrow.up.and.down.and.arrow.left.and.right")
+                            .font(.system(size: 14, weight: .bold))
+                            .foregroundColor(.white)
+                            .frame(width: 32, height: 32)
+                            .background(Color.white.opacity(0.4))
+                            .clipShape(Circle())
+                            .overlay(
+                                Circle()
+                                    .stroke(Color.white, lineWidth: 1.5)
+                            )
+                    }
+
+                    // Widget name label
+                    VStack(spacing: 2) {
+                        let labelText: String = {
+                            var text = widgetInScene.widget.name
+                            if !isClickable {
+                                text += " (Not Clickable)"
+                            }
+                            if isLocked {
+                                text += " (Locked)"
+                            }
+                            if !isEnabled {
+                                text += " (Hidden)"
+                            }
+                            return text
+                        }()
+                        Text(labelText)
+                            .font(.caption2)
+                            .fontWeight(.bold)
+                            .foregroundStyle(.white)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 3)
+                            .background(!isEnabled ? Color.orange :
+                                (isLocked ? Color.red :
+                                    (!isClickable ? Color.gray : Color.black.opacity(0.85))))
+                            .cornerRadius(4)
+                        Spacer()
+                    }
+                    .padding(.top, widgetInScene.widget.hasSize() ? -22 : -28)
+                }
+            }
+            .frame(
+                width: widgetInScene.widget.hasSize() ? max(rect.width, 10) : 44,
+                height: widgetInScene.widget.hasSize() ? max(rect.height, 10) : 44
+            )
+        }
+        .frame(
+            width: widgetInScene.widget.hasSize() ? max(rect.width, 44) : 44,
+            height: widgetInScene.widget.hasSize() ? max(rect.height, 44) : 44
+        )
+        .contentShape(Rectangle())
+        .position(x: rect.midX, y: rect.midY)
+        .allowsHitTesting(true)
+        // Unified gesture handling both TAP and DRAG + PINCH
+        .gesture(
+            DragGesture(minimumDistance: 0, coordinateSpace: .global)
+                .onChanged { value in
+                    guard !isPinching else { return }
+
+                    let dx = value.translation.width
+                    let dy = value.translation.height
+                    let distance = sqrt(dx * dx + dy * dy)
+
+                    // Only move if we exceed the drag threshold of 5 points
+                    if distance > 5 {
+                        // Initialize drag state on actual drag start
+                        if activeDragWidgetId != widgetInScene.id {
+                            activeDragWidgetId = widgetInScene.id
+                            // Convert to topLeft alignment for consistent math
+                            convertToTopLeft(
+                                widgetInScene: widgetInScene,
+                                rect: rect,
+                                videoBounds: videoBounds
+                            )
+                            let layout = widgetInScene.sceneWidget.layout
+                            dragStartLayoutX = layout.x
+                            dragStartLayoutY = layout.y
+                            dragStartTranslationX = dx
+                            dragStartTranslationY = dy
+                        }
+
+                        // Auto-select on drag start
+                        if model.selectedWidgetForInteraction?.id != widgetInScene.id {
+                            triggerHaptic()
+                            model.selectedWidgetForInteraction = widgetInScene
+                        }
+
+                        var layout = widgetInScene.sceneWidget.layout
+                        guard !layout.positioningLock else { return }
+
+                        let (widgetWidth, widgetHeight) = getWidgetDimensions(
+                            widgetInScene: widgetInScene,
+                            videoBounds: videoBounds
+                        )
+
+                        let effectiveDx = dx - dragStartTranslationX
+                        let effectiveDy = dy - dragStartTranslationY
+
+                        var candidateMinX = videoBounds.minX + CGFloat(dragStartLayoutX / 100.0) * videoBounds
+                            .width + effectiveDx
+                        var candidateMinY = videoBounds.minY + CGFloat(dragStartLayoutY / 100.0) * videoBounds
+                            .height + effectiveDy
+
+                        // Apply snapping
+                        applySnapping(
+                            candidateMinX: &candidateMinX,
+                            candidateMinY: &candidateMinY,
+                            widgetWidth: widgetWidth,
+                            widgetHeight: widgetHeight,
+                            videoBounds: videoBounds
+                        )
+
+                        // Convert back to percentage
+                        layout.x = max(
+                            0.0,
+                            Double((candidateMinX - videoBounds.minX) / videoBounds.width) * 100.0
+                        )
+                        layout.y = max(
+                            0.0,
+                            Double((candidateMinY - videoBounds.minY) / videoBounds.height) * 100.0
+                        )
+                        layout.updateXString()
+                        layout.updateYString()
+
+                        widgetInScene.sceneWidget.layout = layout
+
+                        let now = Date()
+                        if now.timeIntervalSince(lastDragUpdate) > 0.033 {
+                            model.updateWidgetLayoutDirectly(
+                                widgetId: widgetInScene.widget.id,
+                                sceneWidget: widgetInScene.sceneWidget
+                            )
+                            lastDragUpdate = now
+                        }
+                    }
+                }
+                .onEnded { value in
+                    let dx = value.translation.width
+                    let dy = value.translation.height
+                    let distance = sqrt(dx * dx + dy * dy)
+
+                    // If user tapped without dragging, toggle selection (and we were not pinching)
+                    if distance <= 5, !isPinching {
+                        triggerHaptic()
+                        if model.selectedWidgetForInteraction?.id == widgetInScene.id {
+                            model.selectedWidgetForInteraction = nil
+                        } else {
+                            model.selectedWidgetForInteraction = widgetInScene
+                        }
+                    } else if distance > 5 {
+                        // Force final layout sync
+                        model.updateWidgetLayoutDirectly(
+                            widgetId: widgetInScene.widget.id,
+                            sceneWidget: widgetInScene.sceneWidget
+                        )
+                    }
+
+                    isPinching = false
+                    activeDragWidgetId = nil
+                    activeSnapX = nil
+                    activeSnapY = nil
+                    hasHapticedX = false
+                    hasHapticedY = false
+                    model.sceneUpdated(attachCamera: false, updateRemoteScene: true)
+                }
+                .simultaneously(with:
+                    MagnificationGesture()
+                        .onChanged { scale in
+                            isPinching = true
+                            // Auto-select on pinch
+                            if model.selectedWidgetForInteraction?.id != widgetInScene.id {
+                                triggerHaptic()
+                                model.selectedWidgetForInteraction = widgetInScene
+                            }
+
+                            var layout = widgetInScene.sceneWidget.layout
+                            guard !layout.positioningLock else { return }
+
+                            if widgetInScene.widget.type == .text {
+                                if pinchStartSize == 0 {
+                                    pinchStartSize = Double(widgetInScene.widget.text.fontSizeFloat)
+                                }
+                                let newSize = (pinchStartSize * Double(scale)).clamped(to: 10 ... 300)
+                                widgetInScene.widget.text.fontSizeFloat = Float(newSize)
+                                widgetInScene.widget.text.fontSize = Int(newSize)
+                                model.objectWillChange.send()
+                                return
+                            }
+
+                            if pinchStartSize == 0 {
+                                pinchStartSize = layout.size
+                            }
+
+                            let newSize = (pinchStartSize * Double(scale)).clamped(to: 1 ... 100)
+                            layout.size = newSize
+                            layout.updateSizeString()
+
+                            widgetInScene.sceneWidget.layout = layout
+                            model.updateWidgetLayoutDirectly(
+                                widgetId: widgetInScene.widget.id,
+                                sceneWidget: widgetInScene.sceneWidget
+                            )
+                        }
+                        .onEnded { _ in
+                            pinchStartSize = 0
+                            model.sceneUpdated(attachCamera: false, updateRemoteScene: true)
+                        })
+        )
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        if model.editWidgetsMode {
+            let videoBounds = getVideoBounds()
+            let widgets = model.widgetsInCurrentScene(onlyEnabled: false)
+
+            ZStack {
+                // Background overlay to deselect when tapping empty space
+                Color.black.opacity(0.15)
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        model.selectedWidgetForInteraction = nil
+                    }
+
+                // Snap guide lines (yellow dashed)
+                if let snapX = activeSnapX {
+                    Path { path in
+                        path.move(to: CGPoint(x: snapX, y: 0))
+                        path.addLine(to: CGPoint(x: snapX, y: previewSize.height))
+                    }
+                    .stroke(Color.yellow, style: StrokeStyle(lineWidth: 1, dash: [4, 3]))
+                    .allowsHitTesting(false)
+                }
+                if let snapY = activeSnapY {
+                    Path { path in
+                        path.move(to: CGPoint(x: 0, y: snapY))
+                        path.addLine(to: CGPoint(x: previewSize.width, y: snapY))
+                    }
+                    .stroke(Color.yellow, style: StrokeStyle(lineWidth: 1, dash: [4, 3]))
+                    .allowsHitTesting(false)
+                }
+
+                // Widget interaction areas
+                ForEach(widgets) { widgetInScene in
+                    let rect = getWidgetRect(widgetInScene: widgetInScene, videoBounds: videoBounds)
+                    let isSelected = model.selectedWidgetForInteraction?.id == widgetInScene.id
+
+                    widgetItemView(widgetInScene: widgetInScene, rect: rect, videoBounds: videoBounds)
+
+                    // Corner handles and HUD for the selected widget
+                    if isSelected {
+                        if widgetInScene.widget.hasSize() {
+                            Group {
+                                cornerHandle(
+                                    x: rect.minX,
+                                    y: rect.minY,
+                                    handle: "topLeft",
+                                    widgetInScene: widgetInScene,
+                                    rect: rect,
+                                    videoBounds: videoBounds
+                                )
+                                cornerHandle(
+                                    x: rect.maxX,
+                                    y: rect.minY,
+                                    handle: "topRight",
+                                    widgetInScene: widgetInScene,
+                                    rect: rect,
+                                    videoBounds: videoBounds
+                                )
+                                cornerHandle(
+                                    x: rect.minX,
+                                    y: rect.maxY,
+                                    handle: "bottomLeft",
+                                    widgetInScene: widgetInScene,
+                                    rect: rect,
+                                    videoBounds: videoBounds
+                                )
+                                cornerHandle(
+                                    x: rect.maxX,
+                                    y: rect.maxY,
+                                    handle: "bottomRight",
+                                    widgetInScene: widgetInScene,
+                                    rect: rect,
+                                    videoBounds: videoBounds
+                                )
+                            }
+                        }
+
+                        hudToolbar(widgetInScene: widgetInScene, rect: rect)
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces an interactive mode to edit, drag, resize, and lock widgets directly on the camera preview without cluttering the core video pipeline.

Architectural Approach
We avoided injecting complex touch handlers into the core Metal / CoreImage pipeline. Instead, we built a 100% declarative SwiftUI overlay (InteractiveWidgetOverlayView.swift) that floats invisibly above the camera preview. It mirrors the exact bounding boxes of the active widgets and uses SwiftUI DragGesture and MagnificationGesture to rewrite the coordinates (SettingsWidgetLayout) in real-time.

Key Changes
1. The Overlay View (InteractiveWidgetOverlayView.swift)
A new standalone SwiftUI component that contains all the layout dragging, pinching, snapping, and HUD logic.
Computes exact dimensions using getWidgetDimensions to ensure the invisible hitboxes perfectly match the widget's real bounds.
Text Widget Fixes: Text widgets don't scale using layout.size. The overlay correctly identifies .text widgets, estimates their bounding box based on fontSizeFloat, and intercepts pinch-to-zoom gestures to inject changes directly into fontSize instead of the layout bounds, avoiding the "giant hitbox" bug.
Smart Locking: Respects Moblin's existing positioningLock. A locked widget can still be selected via tap (to reveal the unlock HUD) but prevents drag and pinch gestures.
2. Model Hooks (ModelScene.swift)
Added updateWidgetLayoutDirectly() to allow the overlay to sync layout changes in real-time during a 60fps drag without constantly writing to the persistent database, saving CPU and avoiding stutter.
3. Integration (MainView.swift & Settings)
Injected InteractiveWidgetOverlayView as an overlay inside MainView.swift.
Added an "Edit layout on screen" toggle inside QuickButtonSceneWidgetsView.swift so the user can easily toggle the feature on/off.
Why this approach?
It is completely non-invasive. If the edit mode is toggled off, the overlay isn't even rendered. It leverages the existing SettingsWidgetLayout and doesn't require rewriting any of the complex widget rendering logic in ImageEffect.swift or TextEffect.swift.



