### PR TITLE
Add region, area, and suburb text widget variables

### DIFF
--- a/Moblin/RemoteControl/RemoteControl.swift
+++ b/Moblin/RemoteControl/RemoteControl.swift
@@ -555,6 +555,9 @@ struct RemoteControlRemoteSceneDataTextStats: Codable {
     var countryFlag: String?
     var state: String?
     var city: String?
+    var region: String?
+    var area: String?
+    var suburb: String?
     var muted: Bool
     var heartRates: [String: Int?]
     var activeEnergyBurned: Int?
@@ -594,6 +597,9 @@ struct RemoteControlRemoteSceneDataTextStats: Codable {
         countryFlag = stats.countryFlag
         state = stats.state
         city = stats.city
+        region = stats.region
+        area = stats.area
+        suburb = stats.suburb
         muted = stats.muted
         heartRates = stats.heartRates
         activeEnergyBurned = stats.activeEnergyBurned
@@ -634,6 +640,9 @@ struct RemoteControlRemoteSceneDataTextStats: Codable {
                         countryFlag: countryFlag,
                         state: state,
                         city: city,
+                        region: region,
+                        area: area,
+                        suburb: suburb,
                         muted: muted,
                         heartRates: heartRates,
                         activeEnergyBurned: activeEnergyBurned,

--- a/Moblin/Various/Model/ModelScene.swift
+++ b/Moblin/Various/Model/ModelScene.swift
@@ -1536,6 +1536,9 @@ extension Model {
                 countryFlag: emojiFlag(countryCode: placemark?.isoCountryCode),
                 state: placemark?.administrativeArea,
                 city: placemark?.locality,
+                region: placemark?.administrativeArea,
+                area: placemark?.subAdministrativeArea,
+                suburb: placemark?.subLocality,
                 muted: isMuteOn,
                 heartRates: heartRates,
                 activeEnergyBurned: workoutActiveEnergyBurned,
@@ -1763,7 +1766,7 @@ extension Model {
     private func updateNeedsGeography(_ text: SettingsWidgetText, _ parts: [TextFormatPart]) {
         text.needsGeography = parts.contains(where: {
             switch $0 {
-            case .country, .countryFlag, .state, .city:
+            case .country, .countryFlag, .state, .city, .region, .area, .suburb:
                 true
             default:
                 false

--- a/Moblin/VideoEffects/Text/TextEffect.swift
+++ b/Moblin/VideoEffects/Text/TextEffect.swift
@@ -26,6 +26,9 @@ struct TextEffectStats {
     let countryFlag: String?
     let state: String?
     let city: String?
+    let region: String?
+    let area: String?
+    let suburb: String?
     let muted: Bool
     let heartRates: [String: Int?]
     let activeEnergyBurned: Int?

--- a/Moblin/VideoEffects/Text/TextEffectFormatter.swift
+++ b/Moblin/VideoEffects/Text/TextEffectFormatter.swift
@@ -137,6 +137,12 @@ class TextEffectFormatter {
                 formatState(stats: stats)
             case .city:
                 formatCity(stats: stats)
+            case .region:
+                formatRegion(stats: stats)
+            case .area:
+                formatArea(stats: stats)
+            case .suburb:
+                formatSuburb(stats: stats)
             case .checkbox:
                 formatCheckbox()
             case .rating:
@@ -341,6 +347,18 @@ class TextEffectFormatter {
 
     private func formatCity(stats: TextEffectStats) {
         appendTextPart(value: stats.city ?? "-")
+    }
+
+    private func formatRegion(stats: TextEffectStats) {
+        appendTextPart(value: stats.region ?? "-")
+    }
+
+    private func formatArea(stats: TextEffectStats) {
+        appendTextPart(value: stats.area ?? "-")
+    }
+
+    private func formatSuburb(stats: TextEffectStats) {
+        appendTextPart(value: stats.suburb ?? "-")
     }
 
     private func formatCheckbox() {

--- a/Moblin/VideoEffects/Text/TextFormatStringLoader.swift
+++ b/Moblin/VideoEffects/Text/TextFormatStringLoader.swift
@@ -61,6 +61,9 @@ enum TextFormatPart: Equatable {
     case countryFlag
     case state
     case city
+    case region
+    case area
+    case suburb
     case checkbox
     case rating
     case subtitles(String?)
@@ -151,6 +154,12 @@ class TextFormatLoader {
                     loadItem(part: .state, offsetBy: 7)
                 } else if formatFromIndex.hasPrefix("{city}") {
                     loadItem(part: .city, offsetBy: 6)
+                } else if formatFromIndex.hasPrefix("{region}") {
+                    loadItem(part: .region, offsetBy: 8)
+                } else if formatFromIndex.hasPrefix("{area}") {
+                    loadItem(part: .area, offsetBy: 6)
+                } else if formatFromIndex.hasPrefix("{suburb}") {
+                    loadItem(part: .suburb, offsetBy: 8)
                 } else if formatFromIndex.hasPrefix("{checkbox}") {
                     loadItem(part: .checkbox, offsetBy: 10)
                 } else if formatFromIndex.hasPrefix("{rating}") {
@@ -395,6 +404,12 @@ extension [TextFormatPart] {
             case .state:
                 return true
             case .city:
+                return true
+            case .region:
+                return true
+            case .area:
+                return true
+            case .suburb:
                 return true
             default:
                 break

--- a/Moblin/View/Settings/Scenes/Widgets/Widget/Text/WidgetTextSettingsView.swift
+++ b/Moblin/View/Settings/Scenes/Widgets/Widget/Text/WidgetTextSettingsView.swift
@@ -728,6 +728,17 @@ private struct LocationVariablesView: View {
                     )
                     VariableView(title: "{state}", description: String(localized: "Show state"), text: $value)
                     VariableView(title: "{city}", description: String(localized: "Show city"), text: $value)
+                    VariableView(
+                        title: "{region}",
+                        description: String(localized: "Show region"),
+                        text: $value
+                    )
+                    VariableView(title: "{area}", description: String(localized: "Show area"), text: $value)
+                    VariableView(
+                        title: "{suburb}",
+                        description: String(localized: "Show suburb"),
+                        text: $value
+                    )
                     VariableView(title: "{speed}", description: String(localized: "Show speed"), text: $value)
                     VariableView(
                         title: "{averageSpeed}",

--- a/MoblinTests/TextEffectSuite.swift
+++ b/MoblinTests/TextEffectSuite.swift
@@ -202,6 +202,46 @@ struct TextEffectSuite {
         #expect(parts == [.subtitles("dk")])
     }
 
+    @Test
+    func loadFormatLocationVariables() {
+        let loader = TextFormatLoader()
+        #expect(loader.load(format: "{region}") == [.region])
+        #expect(loader.load(format: "{area}") == [.area])
+        #expect(loader.load(format: "{suburb}") == [.suburb])
+        #expect(loader.load(format: "{area}, {city}") == [.area, .text(", "), .city])
+    }
+
+    @Test
+    func isLocationVariableForNewVariables() {
+        #expect([TextFormatPart.area].isLocationVariable())
+        #expect([TextFormatPart.region].isLocationVariable())
+        #expect([TextFormatPart.suburb].isLocationVariable())
+    }
+
+    @Test
+    func region() {
+        var lines = format(format: "{region}", stats: createStats())
+        #expect(lines == createLine(data: .text("-")))
+        lines = format(format: "{region}", stats: createStats(region: "Vestland"))
+        #expect(lines == createLine(data: .text("Vestland")))
+    }
+
+    @Test
+    func area() {
+        var lines = format(format: "{area}", stats: createStats())
+        #expect(lines == createLine(data: .text("-")))
+        lines = format(format: "{area}", stats: createStats(area: "Aurland"))
+        #expect(lines == createLine(data: .text("Aurland")))
+    }
+
+    @Test
+    func suburb() {
+        var lines = format(format: "{suburb}", stats: createStats())
+        #expect(lines == createLine(data: .text("-")))
+        lines = format(format: "{suburb}", stats: createStats(suburb: "Fretheim"))
+        #expect(lines == createLine(data: .text("Fretheim")))
+    }
+
     private func format(format: String, stats: TextEffectStats) -> [TextEffectLine] {
         let formatter = TextEffectFormatter(formatParts: loadTextFormat(format: format),
                                             timersEndTime: [],
@@ -214,7 +254,10 @@ struct TextEffectSuite {
 
     private func createStats(conditions: String? = nil,
                              heartRates: [String: Int?] = [:],
-                             gForce: GForce? = nil) -> TextEffectStats
+                             gForce: GForce? = nil,
+                             region: String? = nil,
+                             area: String? = nil,
+                             suburb: String? = nil) -> TextEffectStats
     {
         TextEffectStats(timestamp: .now,
                         bitrate: "",
@@ -238,6 +281,9 @@ struct TextEffectSuite {
                         countryFlag: nil,
                         state: nil,
                         city: nil,
+                        region: region,
+                        area: area,
+                        suburb: suburb,
                         muted: false,
                         heartRates: heartRates,
                         activeEnergyBurned: nil,


### PR DESCRIPTION
## Summary
Adds `{region}`, `{area}`, and `{suburb}` text-widget variables, mirroring the existing `{city}`/`{state}` variables. These map onto the `CLPlacemark` fields the app already resolves via `GeographyManager`:

- `{region}` -> `administrativeArea` (a travel-friendly alias of the existing `{state}`)
- `{area}` -> `subAdministrativeArea` (county/district) -- not previously exposed
- `{suburb}` -> `subLocality` (neighborhood/suburb) -- not previously exposed

`{region}` and `{state}` intentionally both map to `administrativeArea`; `{state}` is kept for backward compatibility while `{region}` is the country-agnostic name requested in the issue.

## Why this matters
Travel and IRL streamers want to surface more geographic hierarchy than just `{city}`, especially in countries where "state" is the wrong label. The placemark already carries county/district and neighborhood data, so this just wires the existing values through the text pipeline. https://github.com/eerimoq/moblin/issues/363

## What changed
The three variables are wired through every stage of the text pipeline exactly like `{city}`:
- `TextFormatStringLoader.swift`: new enum cases, parse branches, and `isLocationVariable()` entries.
- `TextEffect.swift`: new `TextEffectStats` fields.
- `TextEffectFormatter.swift`: render cases plus `formatRegion`/`formatArea`/`formatSuburb` (`?? "-"` fallback, matching `formatCity`).
- `ModelScene.swift`: populate from the placemark and include the new cases in `updateNeedsGeography`.
- `RemoteControl.swift`: new fields on `RemoteControlRemoteSceneDataTextStats` plus `init(stats:)` and `toStats()` pass-through, so remote-scene streamers get the values too.
- `WidgetTextSettingsView.swift` + `Localizable.xcstrings`: list the new variables in the Text widget variable picker.

## Testing
Added parse and render tests to `MoblinTests/TextEffectSuite.swift` (parse of `{region}`/`{area}`/`{suburb}`, mixed `{area}, {city}`, present/absent render, and `isLocationVariable()`), and extended `createStats()` with the new fields.

I could not run the test suite headlessly: Moblin builds only through Xcode and requires a configured `Config/User.xcconfig` (DEVELOPMENT_TEAM / bundle identifier) plus full SPM resolution, neither of which is available in my environment. The change is a line-for-line mirror of the existing `{city}`/`{state}` implementation across all pipeline stages. Please run `Command + U` in Xcode to confirm.

Fixes #363
