### PR TITLE
Bonding public overlay

### DIFF
--- a/Moblin/RemoteControl/RemoteControl.swift
+++ b/Moblin/RemoteControl/RemoteControl.swift
@@ -580,6 +580,8 @@ struct RemoteControlRemoteSceneDataTextStats: Codable {
     let gForce: GForce?
     let latestSubscriber: String
     let latestFollower: String
+    let bonding: String
+    let bondingRtts: String
 
     init(stats: TextEffectStats) {
         bitrate = stats.bitrate
@@ -621,6 +623,8 @@ struct RemoteControlRemoteSceneDataTextStats: Codable {
         gForce = stats.gForce
         latestSubscriber = stats.latestSubscriber
         latestFollower = stats.latestFollower
+        bonding = stats.bonding
+        bondingRtts = stats.bondingRtts
     }
 
     func toStats() -> TextEffectStats {
@@ -663,7 +667,9 @@ struct RemoteControlRemoteSceneDataTextStats: Codable {
                         browserTitle: browserTitle,
                         gForce: gForce,
                         latestSubscriber: latestSubscriber,
-                        latestFollower: latestFollower)
+                        latestFollower: latestFollower,
+                        bonding: bonding,
+                        bondingRtts: bondingRtts)
     }
 }
 

--- a/Moblin/Various/Model/ModelScene.swift
+++ b/Moblin/Various/Model/ModelScene.swift
@@ -1553,7 +1553,9 @@ extension Model {
                 browserTitle: getBrowserTitle(),
                 gForce: gForceManager?.getLatest(),
                 latestSubscriber: latestSubscriber,
-                latestFollower: latestFollower
+                latestFollower: latestFollower,
+                bonding: bonding.statistics,
+                bondingRtts: bonding.rtts
             )
             remoteControlAssistantSetRemoteSceneDataTextStats(stats: stats)
         }

--- a/Moblin/VideoEffects/Text/TextEffect.swift
+++ b/Moblin/VideoEffects/Text/TextEffect.swift
@@ -44,6 +44,8 @@ struct TextEffectStats {
     let gForce: GForce?
     let latestSubscriber: String
     let latestFollower: String
+    let bonding: String
+    let bondingRtts: String
 }
 
 private class TextViewState: ObservableObject {

--- a/Moblin/VideoEffects/Text/TextEffectFormatter.swift
+++ b/Moblin/VideoEffects/Text/TextEffectFormatter.swift
@@ -195,6 +195,10 @@ class TextEffectFormatter {
                 formatLatestSubscriber(stats: stats)
             case .latestFollower:
                 formatLatestFollower(stats: stats)
+            case .bonding:
+                formatBonding(stats: stats)
+            case .bondingRtts:
+                formatBondingRtts(stats: stats)
             }
             partId += 1
         }
@@ -536,6 +540,14 @@ class TextEffectFormatter {
 
     private func formatLatestFollower(stats: TextEffectStats) {
         appendTextPart(value: stats.latestFollower)
+    }
+
+    private func formatBonding(stats: TextEffectStats) {
+        appendTextPart(value: stats.bonding)
+    }
+
+    private func formatBondingRtts(stats: TextEffectStats) {
+        appendTextPart(value: stats.bondingRtts)
     }
 
     private func formatOptional(value: Int?) -> String {

--- a/Moblin/VideoEffects/Text/TextFormatStringLoader.swift
+++ b/Moblin/VideoEffects/Text/TextFormatStringLoader.swift
@@ -276,6 +276,8 @@ enum TextFormatPart: Equatable {
     case gForceMax(String?)
     case latestSubscriber
     case latestFollower
+    case bonding
+    case bondingRtts
 }
 
 @MainActor
@@ -312,6 +314,10 @@ class TextFormatLoader {
                     loadItem(part: .fps, offsetBy: 5)
                 } else if formatFromIndex.hasPrefix("{debugoverlay}") {
                     loadItem(part: .debugOverlay, offsetBy: 14)
+                } else if formatFromIndex.hasPrefix("{bonding}") {
+                    loadItem(part: .bonding, offsetBy: 9)
+                } else if formatFromIndex.hasPrefix("{bondingrtts}") {
+                    loadItem(part: .bondingRtts, offsetBy: 13)
                 } else if appendSpeedIfPresent(formatFromIndex: formatFromIndex) {
                 } else if appendAverageSpeedIfPresent(formatFromIndex: formatFromIndex) {
                 } else if appendAltitudeIfPresent(formatFromIndex: formatFromIndex) {

--- a/Moblin/View/Settings/Scenes/Widgets/Widget/Text/WidgetTextSettingsView.swift
+++ b/Moblin/View/Settings/Scenes/Widgets/Widget/Text/WidgetTextSettingsView.swift
@@ -1119,6 +1119,18 @@ private struct DebugVariablesView: View {
                     text: $value
                 )
                 VariableView(
+                    title: "{bonding}",
+                    description: String(
+                        localized: "Show bonding statistics (e.g. 19% en8, 72% AT&T, 9% T-mobile)"
+                    ),
+                    text: $value
+                )
+                VariableView(
+                    title: "{bondingRtts}",
+                    description: String(localized: "Show bonding RTTs (round-trip times)"),
+                    text: $value
+                )
+                VariableView(
                     title: "{resolution}",
                     description: String(localized: "Show resolution"),
                     text: $value

--- a/MoblinTests/TextEffectSuite.swift
+++ b/MoblinTests/TextEffectSuite.swift
@@ -346,7 +346,9 @@ struct TextEffectSuite {
                         browserTitle: "",
                         gForce: gForce,
                         latestSubscriber: "",
-                        latestFollower: "")
+                        latestFollower: "",
+                        bonding: "",
+                        bondingRtts: "")
     }
 
     private func createLine(data: TextEffectPartData) -> [TextEffectLine] {


### PR DESCRIPTION
Currently, Moblin only displays connection bonding statistics (individual link percentages and RTTs) locally to the streamer via local overlays. This PR exposes these stats to the public audience by adding {bonding} and {bondingRtts} variables to the text overlay widgets.

With this change, streamers can overlay real-time connection health (such as AT&T/T-Mobile usage percentages and latency) directly onto the video frames encoded for the stream.

What this PR adds:
{bonding}: Renders a list of active connection interfaces with their current bandwidth share/percentage (e.g., 19% en8, 72% AT&T, 9% T-mobile).
{bondingRtts}: Renders the round-trip times (RTT) for all active connection interfaces.
Proposed Changes:
TextFormatStringLoader.swift: Added .bonding and .bondingRtts enum cases and parser logic.
TextEffectStats: Extended the stats struct in TextEffect.swift to hold the real-time bonding and bondingRtts strings.
TextEffectFormatter.swift: Implemented formatting cases for rendering the new token values.
ModelScene.swift: Associated the active bonding.statistics and bonding.rtts from the model network loop directly with the text widget update pipeline.
RemoteControl.swift & TextEffectSuite.swift: Maintained remote control API compatibility and updated unit tests.
WidgetTextSettingsView.swift: Added {bonding} and {bondingRtts} suggestions to the Debug variables menu for easy selection.
Verification & Testing:
Verified that the project builds clean without errors using xcodebuild.
Added the variables to text widgets in the settings panel and validated correct overlay updates.