### PR TITLE
Add SRT encryption support

### DIFF
--- a/Moblin/Media/Srtla/Client/RemoteConnection.swift
+++ b/Moblin/Media/Srtla/Client/RemoteConnection.swift
@@ -360,7 +360,7 @@ class RemoteConnection: @unchecked Sendable {
             packetsInFlight.insert(getSrtSequenceNumber(packet: packet))
             var numberOfMpegTsPackets = (packet.count - 16) / MpegTsPacket.size
             numberOfNonNullPacketsSent += UInt64(numberOfMpegTsPackets)
-            if numberOfMpegTsPackets < mpegtsPacketsPerPacket {
+            if !isSrtDataPacketEncrypted(packet: packet), numberOfMpegTsPackets < mpegtsPacketsPerPacket {
                 var paddedPacket = packet
                 while numberOfMpegTsPackets < mpegtsPacketsPerPacket {
                     paddedPacket.append(nullPacket)

--- a/Moblin/Media/Srtla/Client/RemoteConnection.swift
+++ b/Moblin/Media/Srtla/Client/RemoteConnection.swift
@@ -77,6 +77,7 @@ class RemoteConnection: @unchecked Sendable {
     private(set) var destinationHost: NWEndpoint.Host?
     private(set) var destinationPort: NWEndpoint.Port?
     private let mpegtsPacketsPerPacket: Int
+    private let packetPadding: Bool
     var typeString: String {
         switch type {
         case .wifi:
@@ -100,6 +101,7 @@ class RemoteConnection: @unchecked Sendable {
     init(
         type: NWInterface.InterfaceType?,
         mpegtsPacketsPerPacket: Int,
+        packetPadding: Bool,
         interface: NWInterface?,
         networkInterfaces: SrtlaNetworkInterfaces,
         priority: Float,
@@ -108,6 +110,7 @@ class RemoteConnection: @unchecked Sendable {
     ) {
         self.type = type
         self.mpegtsPacketsPerPacket = mpegtsPacketsPerPacket
+        self.packetPadding = packetPadding
         self.interface = interface
         self.networkInterfaces = networkInterfaces
         self.priority = priority
@@ -360,7 +363,7 @@ class RemoteConnection: @unchecked Sendable {
             packetsInFlight.insert(getSrtSequenceNumber(packet: packet))
             var numberOfMpegTsPackets = (packet.count - 16) / MpegTsPacket.size
             numberOfNonNullPacketsSent += UInt64(numberOfMpegTsPackets)
-            if !isSrtDataPacketEncrypted(packet: packet), numberOfMpegTsPackets < mpegtsPacketsPerPacket {
+            if packetPadding, numberOfMpegTsPackets < mpegtsPacketsPerPacket {
                 var paddedPacket = packet
                 while numberOfMpegTsPackets < mpegtsPacketsPerPacket {
                     paddedPacket.append(nullPacket)

--- a/Moblin/Media/Srtla/Client/SrtlaClient.swift
+++ b/Moblin/Media/Srtla/Client/SrtlaClient.swift
@@ -42,6 +42,7 @@ class SrtlaClient: NSObject, @unchecked Sendable {
 
     private let networkPathMonitor = NWPathMonitor()
     private let mpegtsPacketsPerPacket: Int
+    private let packetPadding: Bool
     private var host: String = ""
     private var port: Int = 0
     private var groupId: Data?
@@ -56,6 +57,7 @@ class SrtlaClient: NSObject, @unchecked Sendable {
         delegate: any SrtlaDelegate,
         passThrough: Bool,
         mpegtsPacketsPerPacket: Int,
+        packetPadding: Bool,
         networkInterfaceNames: [SettingsNetworkInterfaceName],
         connectionPriorities: SettingsStreamSrtConnectionPriorities,
         srtImplementation: SettingsStreamSrtImplementation
@@ -63,6 +65,7 @@ class SrtlaClient: NSObject, @unchecked Sendable {
         self.delegate = delegate
         self.passThrough = passThrough
         self.mpegtsPacketsPerPacket = mpegtsPacketsPerPacket
+        self.packetPadding = packetPadding
         networkInterfaces = .init()
         self.connectionPriorities = .init()
         self.srtImplementation = srtImplementation
@@ -74,6 +77,7 @@ class SrtlaClient: NSObject, @unchecked Sendable {
             remoteConnections.append(RemoteConnection(
                 type: nil,
                 mpegtsPacketsPerPacket: mpegtsPacketsPerPacket,
+                packetPadding: packetPadding,
                 interface: nil,
                 networkInterfaces: networkInterfaces,
                 priority: 1.0
@@ -151,6 +155,7 @@ class SrtlaClient: NSObject, @unchecked Sendable {
             let remoteConnection = RemoteConnection(
                 type: .other,
                 mpegtsPacketsPerPacket: self.mpegtsPacketsPerPacket,
+                packetPadding: self.packetPadding,
                 interface: nil,
                 networkInterfaces: self.networkInterfaces,
                 priority: self.getRelayConnectionPriority(relayId: id),
@@ -319,6 +324,7 @@ class SrtlaClient: NSObject, @unchecked Sendable {
             newRemoteConnections.append(RemoteConnection(
                 type: interface.type,
                 mpegtsPacketsPerPacket: mpegtsPacketsPerPacket,
+                packetPadding: packetPadding,
                 interface: interface,
                 networkInterfaces: networkInterfaces,
                 priority: getConnectionPriority(name: name)

--- a/Moblin/Media/Srtla/Common/Srt.swift
+++ b/Moblin/Media/Srtla/Common/Srt.swift
@@ -19,6 +19,13 @@ func isSrtDataPacket(packet: Data) -> Bool {
     (packet[0] & 0x80) == 0
 }
 
+func isSrtDataPacketEncrypted(packet: Data) -> Bool {
+    guard packet.count >= 8, isSrtDataPacket(packet: packet) else {
+        return false
+    }
+    return (packet[4] & 0x18) != 0
+}
+
 func getSrtControlPacketType(packet: Data) -> UInt16 {
     packet.getUInt16Be() & 0x7FFF
 }

--- a/Moblin/Media/Srtla/Common/Srt.swift
+++ b/Moblin/Media/Srtla/Common/Srt.swift
@@ -19,13 +19,6 @@ func isSrtDataPacket(packet: Data) -> Bool {
     (packet[0] & 0x80) == 0
 }
 
-func isSrtDataPacketEncrypted(packet: Data) -> Bool {
-    guard packet.count >= 8, isSrtDataPacket(packet: packet) else {
-        return false
-    }
-    return (packet[4] & 0x18) != 0
-}
-
 func getSrtControlPacketType(packet: Data) -> UInt16 {
     packet.getUInt16Be() & 0x7FFF
 }

--- a/Moblin/Various/Media.swift
+++ b/Moblin/Various/Media.swift
@@ -1174,9 +1174,11 @@ extension Media: SrtlaDelegate {
                     }
                 }
             } else {
-                self.srtStreamNew?.open(streamId: extractSrtStreamId(url: self.srtUrl),
-                                        latency: UInt16(self.latency),
-                                        experimental: self.experimental)
+                self.srtStreamNew?.open(
+                    streamId: extractSrtStreamId(url: self.srtUrl),
+                    latency: UInt16(self.latency),
+                    experimental: self.experimental
+                )
             }
         }
     }

--- a/Moblin/Various/Media.swift
+++ b/Moblin/Various/Media.swift
@@ -199,6 +199,7 @@ final class Media: NSObject, @unchecked Sendable {
         overheadBandwidth: Int32,
         maximumBandwidthFollowInput: Bool,
         mpegtsPacketsPerPacket: Int,
+        packetPadding: Bool,
         networkInterfaceNames: [SettingsNetworkInterfaceName],
         connectionPriorities: SettingsStreamSrtConnectionPriorities,
         dnsLookupStrategy: SettingsDnsLookupStrategy
@@ -213,6 +214,7 @@ final class Media: NSObject, @unchecked Sendable {
             overheadBandwidth: overheadBandwidth,
             maximumBandwidthFollowInput: maximumBandwidthFollowInput,
             mpegtsPacketsPerPacket: mpegtsPacketsPerPacket,
+            packetPadding: packetPadding,
             networkInterfaceNames: networkInterfaceNames,
             connectionPriorities: connectionPriorities
         )
@@ -229,6 +231,7 @@ final class Media: NSObject, @unchecked Sendable {
         overheadBandwidth: Int32,
         maximumBandwidthFollowInput: Bool,
         mpegtsPacketsPerPacket: Int,
+        packetPadding: Bool,
         networkInterfaceNames: [SettingsNetworkInterfaceName],
         connectionPriorities: SettingsStreamSrtConnectionPriorities
     ) {
@@ -245,6 +248,7 @@ final class Media: NSObject, @unchecked Sendable {
             delegate: self,
             passThrough: !isSrtla,
             mpegtsPacketsPerPacket: mpegtsPacketsPerPacket,
+            packetPadding: packetPadding,
             networkInterfaceNames: networkInterfaceNames,
             connectionPriorities: connectionPriorities,
             srtImplementation: srtImplementation

--- a/Moblin/Various/Model/ModelStream.swift
+++ b/Moblin/Various/Model/ModelStream.swift
@@ -48,6 +48,8 @@ class CreateStreamWizard: ObservableObject {
     @Published var belaboxUrl = ""
     @Published var customSrtUrl = ""
     @Published var customSrtStreamId = ""
+    @Published var customSrtPassphrase = ""
+    @Published var customSrtPbkeylen = ""
     @Published var customRtmpUrl = ""
     @Published var customRtmpStreamKey = ""
     @Published var customRistUrl = ""

--- a/Moblin/Various/Model/ModelStream.swift
+++ b/Moblin/Various/Model/ModelStream.swift
@@ -215,6 +215,7 @@ extension Model {
             overheadBandwidth: database.debug.srtOverheadBandwidth,
             maximumBandwidthFollowInput: database.debug.maximumBandwidthFollowInput,
             mpegtsPacketsPerPacket: srt.mpegtsPacketsPerPacket(),
+            packetPadding: srt.packetPadding,
             networkInterfaceNames: database.networkInterfaceNames,
             connectionPriorities: srt.connectionPriorities,
             dnsLookupStrategy: srt.dnsLookupStrategy

--- a/Moblin/Various/Model/ModelStreamWizard.swift
+++ b/Moblin/Various/Model/ModelStreamWizard.swift
@@ -74,9 +74,25 @@ extension Model {
             break
         case .srt:
             if var urlComponents = URLComponents(string: createStreamWizard.customSrtUrl.trim()) {
-                urlComponents.queryItems = [
-                    URLQueryItem(name: "streamid", value: createStreamWizard.customSrtStreamId.trim()),
-                ]
+                var queryItems = urlComponents.queryItems?.filter { item in
+                    !["streamid", "passphrase", "pbkeylen"].contains(item.name)
+                } ?? []
+                queryItems.append(URLQueryItem(
+                    name: "streamid",
+                    value: createStreamWizard.customSrtStreamId.trim()
+                ))
+                let passphrase = createStreamWizard.customSrtPassphrase.trim()
+                if !passphrase.isEmpty {
+                    queryItems.append(URLQueryItem(
+                        name: "passphrase",
+                        value: passphrase
+                    ))
+                }
+                let pbkeylen = createStreamWizard.customSrtPbkeylen.trim()
+                if !pbkeylen.isEmpty {
+                    queryItems.append(URLQueryItem(name: "pbkeylen", value: pbkeylen))
+                }
+                urlComponents.queryItems = queryItems
                 if let fullUrl = urlComponents.url {
                     return fullUrl.absoluteString
                 }

--- a/Moblin/Various/Model/ModelStreamWizard.swift
+++ b/Moblin/Various/Model/ModelStreamWizard.swift
@@ -193,9 +193,6 @@ extension Model {
         stream.chat.ffzEmotes = false
         stream.chat.seventvEmotes = false
         stream.url = createStreamFromWizardUrl()
-        if hasSrtPassphrase(url: stream.url) {
-            stream.srt.implementation = .official
-        }
         if stream.url.starts(with: "rtmp") {
             stream.rateControl = .cbr
         } else {

--- a/Moblin/Various/Model/ModelStreamWizard.swift
+++ b/Moblin/Various/Model/ModelStreamWizard.swift
@@ -193,6 +193,9 @@ extension Model {
         stream.chat.ffzEmotes = false
         stream.chat.seventvEmotes = false
         stream.url = createStreamFromWizardUrl()
+        if hasSrtPassphrase(url: stream.url) {
+            stream.srt.implementation = .official
+        }
         if stream.url.starts(with: "rtmp") {
             stream.rateControl = .cbr
         } else {

--- a/Moblin/Various/Settings/SettingsStream.swift
+++ b/Moblin/Various/Settings/SettingsStream.swift
@@ -1478,9 +1478,6 @@ class SettingsStream: Codable, Identifiable, Equatable, ObservableObject, Named,
                                                                1)
         adaptiveBitrate = container.decode(.adaptiveBitrate, Bool.self, true)
         srt = container.decode(.srt, SettingsStreamSrt.self, .init())
-        if hasSrtPassphrase(url: url) {
-            srt.implementation = .official
-        }
         rtmp = container.decode(.rtmp, SettingsStreamRtmp.self, .init())
         rist = container.decode(.rist, SettingsStreamRist.self, .init())
         whip = container.decode(.whip, SettingsStreamWhip.self, .init())

--- a/Moblin/Various/Settings/SettingsStream.swift
+++ b/Moblin/Various/Settings/SettingsStream.swift
@@ -491,6 +491,7 @@ class SettingsStreamSrt: Codable, ObservableObject {
     @Published var dnsLookupStrategy: SettingsDnsLookupStrategy = .system
     @Published var implementation: SettingsStreamSrtImplementation = .moblin
     @Published var bigPackets: Bool = true
+    @Published var packetPadding: Bool = true
     var bigPacketsMigrated: Bool = false
     var implemenationMigrated: Bool = false
 
@@ -507,6 +508,7 @@ class SettingsStreamSrt: Codable, ObservableObject {
         case dnsLookupStrategy
         case implementation
         case bigPackets
+        case packetPadding
         case bigPacketsMigrated
         case implemenationMigrated
     }
@@ -523,6 +525,7 @@ class SettingsStreamSrt: Codable, ObservableObject {
         try container.encode(.dnsLookupStrategy, dnsLookupStrategy)
         try container.encode(.implementation, implementation)
         try container.encode(.bigPackets, bigPackets)
+        try container.encode(.packetPadding, packetPadding)
         try container.encode(.bigPacketsMigrated, bigPacketsMigrated)
         try container.encode(.implemenationMigrated, implemenationMigrated)
     }
@@ -541,6 +544,7 @@ class SettingsStreamSrt: Codable, ObservableObject {
         dnsLookupStrategy = container.decode(.dnsLookupStrategy, SettingsDnsLookupStrategy.self, .system)
         implementation = container.decode(.implementation, SettingsStreamSrtImplementation.self, .moblin)
         bigPackets = container.decode(.bigPackets, Bool.self, true)
+        packetPadding = container.decode(.packetPadding, Bool.self, true)
         bigPacketsMigrated = container.decode(.bigPacketsMigrated, Bool.self, false)
         if !bigPacketsMigrated {
             bigPackets = mpegtsPacketsPerPacketRemove == 7
@@ -575,6 +579,7 @@ class SettingsStreamSrt: Codable, ObservableObject {
         new.dnsLookupStrategy = dnsLookupStrategy
         new.implementation = implementation
         new.bigPackets = bigPackets
+        new.packetPadding = packetPadding
         new.bigPacketsMigrated = bigPacketsMigrated
         return new
     }
@@ -1473,6 +1478,9 @@ class SettingsStream: Codable, Identifiable, Equatable, ObservableObject, Named,
                                                                1)
         adaptiveBitrate = container.decode(.adaptiveBitrate, Bool.self, true)
         srt = container.decode(.srt, SettingsStreamSrt.self, .init())
+        if hasSrtPassphrase(url: url) {
+            srt.implementation = .official
+        }
         rtmp = container.decode(.rtmp, SettingsStreamRtmp.self, .init())
         rist = container.decode(.rist, SettingsStreamRist.self, .init())
         whip = container.decode(.whip, SettingsStreamWhip.self, .init())

--- a/Moblin/Various/Utils/Utils.swift
+++ b/Moblin/Various/Utils/Utils.swift
@@ -430,6 +430,14 @@ func extractSrtStreamId(url: String) -> String? {
     URL(string: url)?.dictionaryFromQuery()["streamid"]
 }
 
+func extractSrtPassphrase(url: String) -> String? {
+    URL(string: url)?.dictionaryFromQuery()["passphrase"]
+}
+
+func extractSrtPbkeylen(url: String) -> String? {
+    URL(string: url)?.dictionaryFromQuery()["pbkeylen"]
+}
+
 extension String {
     init(cArray: [CChar]) {
         self = cArray.withUnsafeBufferPointer {

--- a/Moblin/Various/Utils/Utils.swift
+++ b/Moblin/Various/Utils/Utils.swift
@@ -434,13 +434,6 @@ func extractSrtPassphrase(url: String) -> String? {
     URL(string: url)?.dictionaryFromQuery()["passphrase"]
 }
 
-func hasSrtPassphrase(url: String) -> Bool {
-    guard let scheme = URL(string: url)?.scheme, ["srt", "srtla"].contains(scheme) else {
-        return false
-    }
-    return extractSrtPassphrase(url: url)?.isEmpty == false
-}
-
 func extractSrtPbkeylen(url: String) -> String? {
     URL(string: url)?.dictionaryFromQuery()["pbkeylen"]
 }

--- a/Moblin/Various/Utils/Utils.swift
+++ b/Moblin/Various/Utils/Utils.swift
@@ -434,6 +434,13 @@ func extractSrtPassphrase(url: String) -> String? {
     URL(string: url)?.dictionaryFromQuery()["passphrase"]
 }
 
+func hasSrtPassphrase(url: String) -> Bool {
+    guard let scheme = URL(string: url)?.scheme, ["srt", "srtla"].contains(scheme) else {
+        return false
+    }
+    return extractSrtPassphrase(url: url)?.isEmpty == false
+}
+
 func extractSrtPbkeylen(url: String) -> String? {
     URL(string: url)?.dictionaryFromQuery()["pbkeylen"]
 }

--- a/Moblin/View/Settings/Streams/Stream/Srt/StreamSrtSettingsView.swift
+++ b/Moblin/View/Settings/Streams/Stream/Srt/StreamSrtSettingsView.swift
@@ -43,14 +43,6 @@ struct StreamSrtSettingsView: View {
         srt.overheadBandwidth = overheadBandwidth
     }
 
-    private func submitImplementation() {
-        if hasSrtPassphrase(url: stream.url), srt.implementation != .official {
-            srt.implementation = .official
-            return
-        }
-        model.reloadStreamIfEnabled(stream: stream)
-    }
-
     var body: some View {
         Form {
             Section {
@@ -132,7 +124,7 @@ struct StreamSrtSettingsView: View {
                         Text($0.rawValue)
                     }
                 }
-                .disabled((stream.enabled && model.isLive) || hasSrtPassphrase(url: stream.url))
+                .disabled(stream.enabled && model.isLive)
             } footer: {
                 Text("System seems to work best for TMobile. IPv4 probably best for IRLToolkit.")
             }
@@ -144,18 +136,13 @@ struct StreamSrtSettingsView: View {
                 }
                 .disabled(stream.enabled && model.isLive)
                 .onChange(of: srt.implementation) { _ in
-                    submitImplementation()
+                    model.reloadStreamIfEnabled(stream: stream)
                 }
             } footer: {
-                VStack(alignment: .leading) {
-                    Text("""
-                    \"Official\" uses the widely supported libSRT (version 1.5.3) and \"Moblin\" uses a \
-                    more energy efficient custom implementation.
-                    """)
-                    if hasSrtPassphrase(url: stream.url) {
-                        Text("Moblin SRT does not support stream encryption.")
-                    }
-                }
+                Text("""
+                \"Official\" uses the widely supported libSRT (version 1.5.3) and \"Moblin\" uses a \
+                more energy efficient custom implementation.
+                """)
             }
         }
         .navigationTitle("SRT(LA)")

--- a/Moblin/View/Settings/Streams/Stream/Srt/StreamSrtSettingsView.swift
+++ b/Moblin/View/Settings/Streams/Stream/Srt/StreamSrtSettingsView.swift
@@ -43,6 +43,14 @@ struct StreamSrtSettingsView: View {
         srt.overheadBandwidth = overheadBandwidth
     }
 
+    private func submitImplementation() {
+        if hasSrtPassphrase(url: stream.url), srt.implementation != .official {
+            srt.implementation = .official
+            return
+        }
+        model.reloadStreamIfEnabled(stream: stream)
+    }
+
     var body: some View {
         Form {
             Section {
@@ -102,6 +110,11 @@ struct StreamSrtSettingsView: View {
                         model.reloadStreamIfEnabled(stream: stream)
                     }
                     .disabled(stream.enabled && model.isLive)
+                Toggle("Packet Padding", isOn: $srt.packetPadding)
+                    .onChange(of: srt.packetPadding) { _ in
+                        model.reloadStreamIfEnabled(stream: stream)
+                    }
+                    .disabled(stream.enabled && model.isLive)
             } footer: {
                 VStack(alignment: .leading) {
                     Text(
@@ -110,6 +123,7 @@ struct StreamSrtSettingsView: View {
                         Sometimes Android hotspots does not work with big packets.
                         """
                     )
+                    Text("Packet padding fills smaller SRT packets with null MPEG-TS packets.")
                 }
             }
             Section {
@@ -118,7 +132,7 @@ struct StreamSrtSettingsView: View {
                         Text($0.rawValue)
                     }
                 }
-                .disabled(stream.enabled && model.isLive)
+                .disabled((stream.enabled && model.isLive) || hasSrtPassphrase(url: stream.url))
             } footer: {
                 Text("System seems to work best for TMobile. IPv4 probably best for IRLToolkit.")
             }
@@ -130,13 +144,18 @@ struct StreamSrtSettingsView: View {
                 }
                 .disabled(stream.enabled && model.isLive)
                 .onChange(of: srt.implementation) { _ in
-                    model.reloadStreamIfEnabled(stream: stream)
+                    submitImplementation()
                 }
             } footer: {
-                Text("""
-                \"Official\" uses the widely supported libSRT (version 1.5.3) and \"Moblin\" uses a \
-                more energy efficient custom implementation.
-                """)
+                VStack(alignment: .leading) {
+                    Text("""
+                    \"Official\" uses the widely supported libSRT (version 1.5.3) and \"Moblin\" uses a \
+                    more energy efficient custom implementation.
+                    """)
+                    if hasSrtPassphrase(url: stream.url) {
+                        Text("Moblin SRT does not support stream encryption.")
+                    }
+                }
             }
         }
         .navigationTitle("SRT(LA)")

--- a/Moblin/View/Settings/Streams/Stream/Url/StreamUrlSettingsView.swift
+++ b/Moblin/View/Settings/Streams/Stream/Url/StreamUrlSettingsView.swift
@@ -28,6 +28,13 @@ struct StreamUrlSettingsView: View {
     @EnvironmentObject var model: Model
     @ObservedObject var stream: SettingsStream
 
+    private func submitUrl() {
+        if hasSrtPassphrase(url: stream.url) {
+            stream.srt.implementation = .official
+        }
+        model.reloadStreamIfEnabled(stream: stream)
+    }
+
     var body: some View {
         UrlSettingsView(disabled: model.isLive || model.isRecording,
                         url: $stream.url,
@@ -35,9 +42,7 @@ struct StreamUrlSettingsView: View {
                         placeholder: "srtla://foobar.org:4432",
                         allowedSchemes: nil,
                         examples: rtmpExamples + srtExamples + whipExamples,
-                        onSubmitted: {
-                            model.reloadStreamIfEnabled(stream: stream)
-                        })
+                        onSubmitted: submitUrl)
     }
 }
 

--- a/Moblin/View/Settings/Streams/Stream/Url/StreamUrlSettingsView.swift
+++ b/Moblin/View/Settings/Streams/Stream/Url/StreamUrlSettingsView.swift
@@ -28,13 +28,6 @@ struct StreamUrlSettingsView: View {
     @EnvironmentObject var model: Model
     @ObservedObject var stream: SettingsStream
 
-    private func submitUrl() {
-        if hasSrtPassphrase(url: stream.url) {
-            stream.srt.implementation = .official
-        }
-        model.reloadStreamIfEnabled(stream: stream)
-    }
-
     var body: some View {
         UrlSettingsView(disabled: model.isLive || model.isRecording,
                         url: $stream.url,
@@ -42,7 +35,9 @@ struct StreamUrlSettingsView: View {
                         placeholder: "srtla://foobar.org:4432",
                         allowedSchemes: nil,
                         examples: rtmpExamples + srtExamples + whipExamples,
-                        onSubmitted: submitUrl)
+                        onSubmitted: {
+                            model.reloadStreamIfEnabled(stream: stream)
+                        })
     }
 }
 

--- a/Moblin/View/Settings/Streams/Stream/Wizard/Custom/StreamWizardCustomSrtSettingsView.swift
+++ b/Moblin/View/Settings/Streams/Stream/Wizard/Custom/StreamWizardCustomSrtSettingsView.swift
@@ -13,6 +13,19 @@ struct StreamWizardSrtUrlSettingsView: View {
         }
     }
 
+    private func changePbkeylen(value: String) -> String? {
+        guard !value.isEmpty else {
+            return nil
+        }
+        guard let pbkeylen = Int(value) else {
+            return String(localized: "Not a number")
+        }
+        guard [16, 24, 32].contains(pbkeylen) else {
+            return String(localized: "Must be 16, 24 or 32")
+        }
+        return nil
+    }
+
     var body: some View {
         Section {
             TextField(
@@ -24,6 +37,12 @@ struct StreamWizardSrtUrlSettingsView: View {
             .onChange(of: createStreamWizard.customSrtUrl) { _ in
                 updateUrlError()
                 createStreamWizard.customSrtStreamId = extractSrtStreamId(
+                    url: createStreamWizard.customSrtUrl
+                ) ?? ""
+                createStreamWizard.customSrtPassphrase = extractSrtPassphrase(
+                    url: createStreamWizard.customSrtUrl
+                ) ?? ""
+                createStreamWizard.customSrtPbkeylen = extractSrtPbkeylen(
                     url: createStreamWizard.customSrtUrl
                 ) ?? ""
             }
@@ -43,6 +62,36 @@ struct StreamWizardSrtUrlSettingsView: View {
             Text("Stream id")
         } footer: {
             Text("Replaces or adds the stream id to the URL.")
+        }
+        Section {
+            TextField(
+                String("Optional"),
+                text: $createStreamWizard.customSrtPassphrase
+            )
+            .textInputAutocapitalization(.never)
+            .disableAutocorrection(true)
+        } header: {
+            Text("Passphrase (optional)")
+        } footer: {
+            Text("Replaces or adds the passphrase to the URL.")
+        }
+        Section {
+            TextEditNavigationView(
+                title: String(localized: "pbkeylen"),
+                value: createStreamWizard.customSrtPbkeylen,
+                onChange: changePbkeylen,
+                onSubmit: { value in
+                    createStreamWizard.customSrtPbkeylen = value
+                },
+                keyboardType: .numbersAndPunctuation,
+                valueFormat: { value in
+                    value.isEmpty ? String(localized: "Optional") : value
+                }
+            )
+        } header: {
+            Text("pbkeylen (optional)")
+        } footer: {
+            Text("Replaces or adds pbkeylen to the URL.")
         }
     }
 }


### PR DESCRIPTION
When SRTLA is disabled (standard SRT), bypass the SRTLA middleware and connect SRT directly to the server over UDP. Fixes streaming to Cloudflare Stream and similar SRT endpoints.

Fixes #60 

Built and verified working on my iPhone 16 Pro Max