### PR TITLE
Fix log share view scroll

### DIFF
--- a/Moblin/View/Settings/Debug/DebugLogSettingsView.swift
+++ b/Moblin/View/Settings/Debug/DebugLogSettingsView.swift
@@ -8,6 +8,12 @@ struct DebugLogSettingsView: View {
     @Binding var presentingLog: Bool
     let reloadLog: () -> Void
     let clearLog: () -> Void
+    @State private var shareItem: ShareItem?
+
+    private struct ShareItem: Identifiable {
+        let id = UUID()
+        let url: URL
+    }
 
     private func isMessageVisible(message: String) -> Bool {
         debug.logFilter.isEmpty || message.lowercased().contains(debug.logFilter.lowercased())
@@ -39,10 +45,17 @@ struct DebugLogSettingsView: View {
             }
             .navigationTitle("Log")
             .navigationBarTitleDisplayMode(.inline)
+            .sheet(item: $shareItem) { item in
+                ShareSheetView(activityItems: [item.url], applicationActivities: nil)
+            }
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
-                    ShareLink(item: model
-                        .formatLog(log: log.filter { isMessageVisible(message: $0.message) }))
+                    Button {
+                        shareItem = ShareItem(url: model
+                            .formatLog(log: log.filter { isMessageVisible(message: $0.message) }))
+                    } label: {
+                        Image(systemName: "square.and.arrow.up")
+                    }
                 }
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button {

--- a/Moblin/View/Utils/ShareSheetView.swift
+++ b/Moblin/View/Utils/ShareSheetView.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+struct ShareSheetView: UIViewControllerRepresentable {
+    let activityItems: [Any]
+    let applicationActivities: [UIActivity]?
+
+    func makeUIViewController(context _: Context) -> UIActivityViewController {
+        UIActivityViewController(
+            activityItems: activityItems,
+            applicationActivities: applicationActivities
+        )
+    }
+
+    func updateUIViewController(_: UIActivityViewController, context _: Context) {}
+}


### PR DESCRIPTION
"The original code used a SwiftUI ShareLink inside a ToolbarItem in a view presented via .fullScreenCover. On iOS, ShareLink in a toolbar can have its presentation anchor invalidated when the share sheet's internal scroll view finishes a gesture and the finger is lifted. When that happens, SwiftUI re-evaluates the toolbar, the ShareLink's anchor changes, and the share sheet dismisses unexpectedly.

The fix replaces the toolbar ShareLink with a plain Button that:

1. Prepares the log file/URL once and stores it in a @State array.
2. Sets a @State flag to true.
3. Triggers a .sheet(isPresented:) that presents a UIActivityViewController wrapper (ShareSheetView).

Because the share sheet is now presented from the view itself via .sheet rather than from a toolbar ShareLink, the presentation anchor is stable and survives scrolling and finger-lift gestures in the share sheet."