### PR TITLE
Add telemetry topic to browser widget JS API

### DIFF
--- a/Moblin/Various/Model/ModelScene.swift
+++ b/Moblin/Various/Model/ModelScene.swift
@@ -1514,7 +1514,7 @@ extension Model {
     }
 
     func updateTextEffects(now: Date, timestamp: ContinuousClock.Instant) {
-        guard !textEffects.isEmpty else {
+        guard !textEffects.isEmpty || !browserEffects.isEmpty else {
             return
         }
         var stats: TextEffectStats
@@ -1568,6 +1568,40 @@ extension Model {
                 latestFollower: latestFollower
             )
             remoteControlAssistantSetRemoteSceneDataTextStats(stats: stats)
+            if !browserEffects.isEmpty {
+                let telemetry = TelemetryData(
+                    speed: location?.speed ?? 0,
+                    averageSpeed: averageSpeed,
+                    altitude: location?.altitude ?? 0,
+                    latitude: location?.coordinate.latitude,
+                    longitude: location?.coordinate.longitude,
+                    distance: database.location.distance,
+                    splitDistance: database.location.splitDistance,
+                    slopePercent: slopePercent,
+                    temperature: weather?.temperature.converted(to: .celsius).value,
+                    feelsLikeTemperature: weather?.apparentTemperature.converted(to: .celsius).value,
+                    windSpeed: weather?.wind.speed.converted(to: .metersPerSecond).value,
+                    windGust: weather?.wind.gust?.converted(to: .metersPerSecond).value,
+                    country: placemark?.country,
+                    countryFlag: emojiFlag(countryCode: placemark?.isoCountryCode),
+                    state: placemark?.administrativeArea,
+                    area: placemark?.subAdministrativeArea,
+                    city: placemark?.locality,
+                    neighborhood: placemark?.subLocality,
+                    heartRates: heartRates,
+                    activeEnergyBurned: workoutActiveEnergyBurned,
+                    workoutDistance: workoutDistance,
+                    power: workoutPower,
+                    stepCount: workoutStepCount,
+                    cyclingPower: cyclingPower,
+                    cyclingCadence: cyclingCadence,
+                    runningMetrics: runningMetrics,
+                    gForce: gForceManager?.getLatest()
+                )
+                for browserEffect in browserEffects.values {
+                    browserEffect.sendTelemetry(telemetry)
+                }
+            }
         }
         for effect in textEffects.values {
             effect.updateStats(stats: stats)

--- a/Moblin/VideoEffects/Browser/BrowserEffect.swift
+++ b/Moblin/VideoEffects/Browser/BrowserEffect.swift
@@ -136,6 +136,11 @@ final class BrowserEffect: VideoEffect, ObservableObject, @unchecked Sendable {
         server.sendSpeechToTextClear()
     }
 
+    @MainActor
+    func sendTelemetry(_ data: TelemetryData) {
+        server.sendTelemetry(data)
+    }
+
     var host: String {
         url.host() ?? "?"
     }

--- a/Moblin/VideoEffects/Browser/BrowserEffectServer.swift
+++ b/Moblin/VideoEffects/Browser/BrowserEffectServer.swift
@@ -12,12 +12,44 @@ private enum PublishMessage: Codable {
 private enum SubscribeTopic: Codable {
     case chat(prefix: String?)
     case speechToText
+    case telemetry
 }
 
 private enum Message: Codable {
     case chat(message: ChatMessage)
     case speechToText(position: Int, text: String)
     case speechToTextClear
+    case telemetry(data: TelemetryData)
+}
+
+struct TelemetryData: Codable {
+    var speed: Double
+    var averageSpeed: Double
+    var altitude: Double
+    var latitude: Double?
+    var longitude: Double?
+    var distance: Double
+    var splitDistance: Double
+    var slopePercent: Double
+    var temperature: Double?
+    var feelsLikeTemperature: Double?
+    var windSpeed: Double?
+    var windGust: Double?
+    var country: String?
+    var countryFlag: String?
+    var state: String?
+    var area: String?
+    var city: String?
+    var neighborhood: String?
+    var heartRates: [String: Int?]
+    var activeEnergyBurned: Int?
+    var workoutDistance: Int?
+    var power: Int?
+    var stepCount: Int?
+    var cyclingPower: Int
+    var cyclingCadence: Int
+    var runningMetrics: [String: WorkoutDeviceRunningMetrics]
+    var gForce: GForce?
 }
 
 private struct ChatMessage: Codable {
@@ -60,6 +92,7 @@ private struct Chat {
 private class Subscriptions {
     var chat: Chat?
     var speechToText: Bool = false
+    var telemetry: Bool = false
 }
 
 @MainActor
@@ -124,6 +157,13 @@ class BrowserEffectServer: NSObject {
         send(message: .message(data: .speechToTextClear))
     }
 
+    func sendTelemetry(_ data: TelemetryData) {
+        guard subscriptions.telemetry else {
+            return
+        }
+        send(message: .message(data: .telemetry(data: data)))
+    }
+
     private func handlePingTimer() {
         if !gotPing {
             logger.info("browser-effect-server: Ping timeout")
@@ -184,6 +224,8 @@ class BrowserEffectServer: NSObject {
             subscriptions.chat = .init(prefix: prefix)
         case .speechToText:
             subscriptions.speechToText = true
+        case .telemetry:
+            subscriptions.telemetry = true
         }
     }
 }


### PR DESCRIPTION
Lets web overlays subscribe to real-time telemetry (speed, altitude, location, distance, heart rate, weather, workout data) via moblin.subscribe({telemetry: {}}), matching the existing chat and speechToText topics. Gated by the existing "Moblin access" widget setting, delivered once per second alongside text widget updates.

Would update is per once ascent / descent variables are available