### PR TITLE
Fix control bar page indicator showing dots for empty quick-button pages

### DIFF
--- a/Moblin/View/ControlBar/ControlBarLandscapeView.swift
+++ b/Moblin/View/ControlBar/ControlBarLandscapeView.swift
@@ -235,20 +235,18 @@ private struct ControlBarPageScrollTargetBehavior: @preconcurrency ScrollTargetB
 private struct PageIndicatorView: View {
     @ObservedObject var quickButtons: QuickButtons
 
-    private var visiblePageIds: [Int] {
-        var ids: [Int] = [1]
-        for page in 1 ..< controlBarPages {
-            if !quickButtons.pairs[page].isEmpty {
-                ids.append(page + 1)
-            }
+    private var visiblePages: [Int] {
+        var pages: [Int] = [1]
+        for page in 1 ..< controlBarPages where !quickButtons.pairs[page].isEmpty {
+            pages.append(page + 1)
         }
-        return ids
+        return pages
     }
 
     var body: some View {
         HStack(spacing: 3) {
-            ForEach(visiblePageIds, id: \.self) { pageId in
-                Image(systemName: quickButtons.activePage == pageId ? "circle.fill" : "circle")
+            ForEach(visiblePages, id: \.self) { page in
+                Image(systemName: quickButtons.activePage == page ? "circle.fill" : "circle")
                     .font(.system(size: 5))
                     .padding(.bottom, 0)
                     .foregroundStyle(.white)

--- a/Moblin/View/ControlBar/ControlBarLandscapeView.swift
+++ b/Moblin/View/ControlBar/ControlBarLandscapeView.swift
@@ -235,10 +235,20 @@ private struct ControlBarPageScrollTargetBehavior: @preconcurrency ScrollTargetB
 private struct PageIndicatorView: View {
     @ObservedObject var quickButtons: QuickButtons
 
+    private var visiblePageIds: [Int] {
+        var ids: [Int] = [1]
+        for page in 1 ..< controlBarPages {
+            if !quickButtons.pairs[page].isEmpty {
+                ids.append(page + 1)
+            }
+        }
+        return ids
+    }
+
     var body: some View {
         HStack(spacing: 3) {
-            ForEach(1 ... controlBarPages, id: \.self) { page in
-                Image(systemName: quickButtons.activePage == page ? "circle.fill" : "circle")
+            ForEach(visiblePageIds, id: \.self) { pageId in
+                Image(systemName: quickButtons.activePage == pageId ? "circle.fill" : "circle")
                     .font(.system(size: 5))
                     .padding(.bottom, 0)
                     .foregroundStyle(.white)

--- a/Moblin/View/ControlBar/ControlBarLandscapeView.swift
+++ b/Moblin/View/ControlBar/ControlBarLandscapeView.swift
@@ -235,7 +235,7 @@ private struct ControlBarPageScrollTargetBehavior: @preconcurrency ScrollTargetB
 private struct PageIndicatorView: View {
     @ObservedObject var quickButtons: QuickButtons
 
-    private var visiblePages: [Int] {
+    private func visiblePages() -> [Int] {
         var pages: [Int] = [1]
         for page in 1 ..< controlBarPages where !quickButtons.pairs[page].isEmpty {
             pages.append(page + 1)
@@ -245,7 +245,7 @@ private struct PageIndicatorView: View {
 
     var body: some View {
         HStack(spacing: 3) {
-            ForEach(visiblePages, id: \.self) { page in
+            ForEach(visiblePages(), id: \.self) { page in
                 Image(systemName: quickButtons.activePage == page ? "circle.fill" : "circle")
                     .font(.system(size: 5))
                     .padding(.bottom, 0)


### PR DESCRIPTION
## Bug Fixing (UI)
### Page indicator number bug

<img width="1278" height="590" alt="Screenshot 2026-07-13 at 21 12 44" src="https://github.com/user-attachments/assets/1f518326-4689-4a57-aa8c-0cb2a9f9cadf" />

### Root Cause and Solution

PageIndicatorView hardcoded 5 dots (1 ... controlBarPages) while PagesView only renders PageViews for non-empty quick-button pages, causing ghost dots with no corresponding swipeable page and wrong active-dot highlighting when intermediate pages were empty. Derive the dot list from the same set of page ids PagesView uses so the indicator always matches visible pages.