### PR TITLE
fix: Low Light Boost respects configured FPS as maximum (e.g. 50)

### DIFF
--- a/Moblin/Media/HaishinKit/Media/Video/VideoUnit.swift
+++ b/Moblin/Media/HaishinKit/Media/Video/VideoUnit.swift
@@ -1904,7 +1904,7 @@ final class VideoUnit: NSObject, @unchecked Sendable {
             }
             device.activeColorSpace = colorSpace
             if useAutoFrameRate {
-                device.setAutoFps()
+                device.setAutoFps(maxFrameRate: fps)
                 processor?.delegate.streamSelectedFps(auto: true)
             } else {
                 device.setFps(frameRate: fps)

--- a/Moblin/Various/Utils/CameraUtils.swift
+++ b/Moblin/Various/Utils/CameraUtils.swift
@@ -39,8 +39,8 @@ extension AVCaptureDevice {
         activeVideoMaxFrameDuration = CMTime(value: 100, timescale: CMTimeScale(100 * frameRate))
     }
 
-    func setAutoFps() {
-        activeVideoMinFrameDuration = .invalid
+    func setAutoFps(maxFrameRate: Float64) {
+        activeVideoMinFrameDuration = CMTime(value: 100, timescale: CMTimeScale(100 * maxFrameRate))
         activeVideoMaxFrameDuration = .invalid
         if #available(iOS 18, *) {
             isAutoVideoFrameRateEnabled = true


### PR DESCRIPTION
Fixes #409

With Low Light Boost on, `setAutoFps()` left min frame duration invalid so the camera could peak at format max (often 60 FPS) in normal light.

Cap `activeVideoMinFrameDuration` to the configured stream FPS so LLB can still lower FPS in the dark but not go above the setting (e.g. 50).