### PR TITLE
OSP chat: support optional per-message nickname color

### DIFF
--- a/Moblin/StreamingPlatforms/OpenStreamingPlatform/OpenStreamingPlatformChat.swift
+++ b/Moblin/StreamingPlatforms/OpenStreamingPlatform/OpenStreamingPlatformChat.swift
@@ -4,6 +4,11 @@ import XMLCoder
 private struct Message: Codable {
     let from: String
     let body: String
+    // Optional per-message nickname color as a 6-digit hex string (no "#"),
+    // e.g. "bcc2cf". Not part of core XMPP MUC; servers that don't send it
+    // simply omit the attribute, which decodes to nil here and behaves
+    // exactly as before.
+    let color: String?
 
     func user() -> String? {
         guard let slashIndex = from.firstIndex(of: "/") else {
@@ -231,7 +236,7 @@ class OpenStreamingPlatformChat: @unchecked Sendable {
                                 displayName: user,
                                 user: user,
                                 userId: nil,
-                                userColor: nil,
+                                userColor: RgbColor.fromHex(string: message.color ?? ""),
                                 userBadges: [],
                                 segments: segments,
                                 timestamp: model.statusOther.digitalClock,


### PR DESCRIPTION
## Motivation

The Open Streaming Platform chat client (`OpenStreamingPlatformChat.swift`) always passes `userColor: nil` when handing a message to `appendChatMessage`, since the `Message` struct it decodes only has `from`/`body`. There's no field in the code path to carry a per-user color, so every OSP message falls back to the single global `database.chat.usernameColor` setting -- every chatter renders in the same color, unlike Twitch/Kick/YouTube/Soop where each platform's native color is threaded through.

I maintain a third-party OSP-compatible chat bridge (for a platform Moblin doesn't natively support) that already has real per-user nickname colors available from its upstream API, and would like to pass them through to Moblin's OSP chat overlay instead of losing them.

## Change

Adds an optional `color` attribute on the `<message>` stanza, decoded into a new optional `Message.color: String?` field, and used via the same `RgbColor.fromHex(string:)` helper `TwitchChat.swift` already uses for Twitch's IRC `color` tag.

```diff
 private struct Message: Codable {
     let from: String
     let body: String
+    let color: String?
```
```diff
-                                userColor: nil,
+                                userColor: RgbColor.fromHex(string: message.color ?? ""),
```

This is fully backward compatible: `color` is optional, so any OSP server that doesn't send it (the current behavior) decodes to `nil` and nothing changes. `type="groupchat"` on the same stanza is already an attribute the current `Message` struct doesn't declare and silently ignores, which is what makes me confident an unknown/absent extra attribute is safe here.