### PR TITLE
Add BLE cycling speed and cadence (CSC) workout device support

### DIFF
--- a/Moblin/Integrations/WorkoutDevice/WorkoutDevice.swift
+++ b/Moblin/Integrations/WorkoutDevice/WorkoutDevice.swift
@@ -6,6 +6,7 @@ private let dispatchQueue = DispatchQueue(label: "com.eerimoq.workout-device")
 nonisolated(unsafe) let workoutDeviceScanner = BluetoothScanner(serviceIds: [
     workoutDeviceHeartRateServiceId,
     workoutDeviceCyclingPowerServiceId,
+    workoutDeviceCyclingSpeedCadenceServiceId,
     workoutDeviceRunningServiceId,
 ])
 
@@ -13,6 +14,7 @@ protocol WorkoutDeviceDelegate: AnyObject {
     func workoutDeviceState(_ device: WorkoutDevice, state: WorkoutDeviceState)
     func workoutDeviceHeartRate(_ device: WorkoutDevice, heartRate: Int)
     func workoutDeviceCyclingPower(_ device: WorkoutDevice, power: Int, cadence: Int)
+    func workoutDeviceCyclingSpeedCadence(_ device: WorkoutDevice, cadence: Int)
     func workoutDeviceRunningMetrics(_ device: WorkoutDevice, metrics: WorkoutDeviceRunningMetrics)
 }
 
@@ -29,6 +31,7 @@ class WorkoutDevice: NSObject, @unchecked Sendable {
     private var peripheral: CBPeripheral?
     private let heartRate = WorkoutDeviceHeartRate()
     private let cyclingPower = WorkoutDeviceCyclingPower()
+    private let cyclingSpeedCadence = WorkoutDeviceCyclingSpeedCadence()
     private let running = WorkoutDeviceRunning()
     private var deviceId: UUID?
     weak var delegate: (any WorkoutDeviceDelegate)?
@@ -64,6 +67,7 @@ class WorkoutDevice: NSObject, @unchecked Sendable {
         peripheral = nil
         heartRate.reset()
         cyclingPower.reset()
+        cyclingSpeedCadence.reset()
         running.reset()
         setState(state: .disconnected)
     }
@@ -130,6 +134,9 @@ extension WorkoutDevice: CBCentralManagerDelegate {
         if cyclingPower.isAnyCharacteristicDiscovered() {
             return true
         }
+        if cyclingSpeedCadence.isAnyCharacteristicDiscovered() {
+            return true
+        }
         if running.isAnyCharacteristicDiscovered() {
             return true
         }
@@ -149,6 +156,11 @@ extension WorkoutDevice: CBCentralManagerDelegate {
         try cyclingPower.handlePowerVector(value: value)
     }
 
+    private func handleCyclingSpeedCadenceMeasurement(value: Data) throws {
+        let cadence = try cyclingSpeedCadence.handleMeasurement(value: value)
+        delegate?.workoutDeviceCyclingSpeedCadence(self, cadence: cadence)
+    }
+
     private func handleRunningMeasurement(value: Data) throws {
         let metrics = try running.handleMeasurement(value: value)
         delegate?.workoutDeviceRunningMetrics(self, metrics: metrics)
@@ -164,6 +176,9 @@ extension WorkoutDevice: CBPeripheralDelegate {
             peripheral.discoverCharacteristics(nil, for: service)
         }
         if let service = services.first(where: { $0.uuid == workoutDeviceCyclingPowerServiceId }) {
+            peripheral.discoverCharacteristics(nil, for: service)
+        }
+        if let service = services.first(where: { $0.uuid == workoutDeviceCyclingSpeedCadenceServiceId }) {
             peripheral.discoverCharacteristics(nil, for: service)
         }
         if let service = services.first(where: { $0.uuid == workoutDeviceRunningServiceId }) {
@@ -183,6 +198,9 @@ extension WorkoutDevice: CBPeripheralDelegate {
                 peripheral?.setNotifyValue(true, for: characteristic)
             case workoutDeviceCyclingPowerMeasurementCharacteristicId:
                 cyclingPower.setMeasurementCharacteristic(characteristic)
+                peripheral?.setNotifyValue(true, for: characteristic)
+            case workoutDeviceCscMeasurementCharacteristicId:
+                cyclingSpeedCadence.setMeasurementCharacteristic(characteristic)
                 peripheral?.setNotifyValue(true, for: characteristic)
             case workoutDeviceRunningMeasurementCharacteristicId:
                 running.setMeasurementCharacteristic(characteristic)
@@ -212,6 +230,8 @@ extension WorkoutDevice: CBPeripheralDelegate {
                 try handleCyclingPowerMeasurement(value: value)
             case workoutDeviceCyclingPowerVectorCharacteristicId:
                 try handleCyclingPowerVector(value: value)
+            case workoutDeviceCscMeasurementCharacteristicId:
+                try handleCyclingSpeedCadenceMeasurement(value: value)
             case workoutDeviceRunningMeasurementCharacteristicId:
                 try handleRunningMeasurement(value: value)
             default:

--- a/Moblin/Integrations/WorkoutDevice/WorkoutDevice.swift
+++ b/Moblin/Integrations/WorkoutDevice/WorkoutDevice.swift
@@ -14,7 +14,7 @@ protocol WorkoutDeviceDelegate: AnyObject {
     func workoutDeviceState(_ device: WorkoutDevice, state: WorkoutDeviceState)
     func workoutDeviceHeartRate(_ device: WorkoutDevice, heartRate: Int)
     func workoutDeviceCyclingPower(_ device: WorkoutDevice, power: Int, cadence: Int)
-    func workoutDeviceCyclingSpeedCadence(_ device: WorkoutDevice, cadence: Int)
+    func workoutDeviceCyclingSpeedCadence(_ device: WorkoutDevice, speed: Double, cadence: Int)
     func workoutDeviceRunningMetrics(_ device: WorkoutDevice, metrics: WorkoutDeviceRunningMetrics)
 }
 
@@ -157,8 +157,8 @@ extension WorkoutDevice: CBCentralManagerDelegate {
     }
 
     private func handleCyclingSpeedCadenceMeasurement(value: Data) throws {
-        let cadence = try cyclingSpeedCadence.handleMeasurement(value: value)
-        delegate?.workoutDeviceCyclingSpeedCadence(self, cadence: cadence)
+        let (speed, cadence) = try cyclingSpeedCadence.handleMeasurement(value: value)
+        delegate?.workoutDeviceCyclingSpeedCadence(self, speed: speed, cadence: cadence)
     }
 
     private func handleRunningMeasurement(value: Data) throws {

--- a/Moblin/Integrations/WorkoutDevice/WorkoutDeviceCyclingSpeedCadence.swift
+++ b/Moblin/Integrations/WorkoutDevice/WorkoutDeviceCyclingSpeedCadence.swift
@@ -4,15 +4,16 @@ import Foundation
 let workoutDeviceCyclingSpeedCadenceServiceId = CBUUID(string: "1816")
 let workoutDeviceCscMeasurementCharacteristicId = CBUUID(string: "2A5B")
 
+/// Default 700×25c tire circumference (Cateye / common bike computer default).
+let workoutDeviceDefaultWheelCircumferenceMeters = 2.105
+
 private let measurementWheelRevolutionDataFlagIndex = 0
 private let measurementCrankRevolutionDataFlagIndex = 1
 
 private let averageSampleCount = 3
 
 private struct CscMeasurement {
-    // periphery:ignore
     var cumulativeWheelRevolutions: UInt32?
-    // periphery:ignore
     var lastWheelEventTime: UInt16?
     var cumulativeCrankRevolutions: UInt16?
     var lastCrankEventTime: UInt16?
@@ -31,7 +32,7 @@ private struct CscMeasurement {
     }
 }
 
-private class AverageCadenceCalculator {
+private class AverageIntCalculator {
     private var values = Array(repeating: 0, count: averageSampleCount)
     private var nextIndex = 0
 
@@ -50,17 +51,43 @@ private class AverageCadenceCalculator {
     }
 }
 
+private class AverageDoubleCalculator {
+    private var values = Array(repeating: 0.0, count: averageSampleCount)
+    private var nextIndex = 0
+
+    func update(value: Double) {
+        values[nextIndex] = value
+        nextIndex += 1
+        nextIndex %= averageSampleCount
+    }
+
+    func averageIgnoreZeros() -> Double {
+        let nonZeroValues = values.filter { $0 != 0 }
+        guard !nonZeroValues.isEmpty else {
+            return 0
+        }
+        return nonZeroValues.reduce(0, +) / Double(nonZeroValues.count)
+    }
+}
+
 class WorkoutDeviceCyclingSpeedCadence {
     private var measurementCharacteristic: CBCharacteristic?
     private var previousCrankRevolutions: UInt16?
     private var previousCrankRevolutionsTime: UInt16?
-    private var averageCadence = AverageCadenceCalculator()
+    private var previousWheelRevolutions: UInt32?
+    private var previousWheelRevolutionsTime: UInt16?
+    private var averageCadence = AverageIntCalculator()
+    private var averageSpeed = AverageDoubleCalculator()
     private var latestAverageCadenceUpdateTime = ContinuousClock.now
+    private var latestAverageSpeedUpdateTime = ContinuousClock.now
+    var wheelCircumferenceMeters = workoutDeviceDefaultWheelCircumferenceMeters
 
     func reset() {
         measurementCharacteristic = nil
         previousCrankRevolutions = nil
         previousCrankRevolutionsTime = nil
+        previousWheelRevolutions = nil
+        previousWheelRevolutionsTime = nil
     }
 
     func setMeasurementCharacteristic(_ characteristic: CBCharacteristic) {
@@ -71,8 +98,15 @@ class WorkoutDeviceCyclingSpeedCadence {
         measurementCharacteristic != nil
     }
 
-    func handleMeasurement(value: Data) throws -> Int {
+    func handleMeasurement(value: Data) throws -> (speedMetersPerSecond: Double, cadence: Int) {
         let measurement = try CscMeasurement(value: value)
+        let now = ContinuousClock.now
+        updateCadence(measurement: measurement, now: now)
+        updateSpeed(measurement: measurement, now: now)
+        return (averageSpeed.averageIgnoreZeros(), averageCadence.averageIgnoreZeros())
+    }
+
+    private func updateCadence(measurement: CscMeasurement, now: ContinuousClock.Instant) {
         var cadence = -1.0
         if let revolutions = measurement.cumulativeCrankRevolutions,
            let time = measurement.lastCrankEventTime
@@ -95,13 +129,42 @@ class WorkoutDeviceCyclingSpeedCadence {
             previousCrankRevolutions = revolutions
             previousCrankRevolutionsTime = time
         }
-        let now = ContinuousClock.now
         if cadence != -1.0 {
             averageCadence.update(value: Int(cadence))
             latestAverageCadenceUpdateTime = now
         } else if latestAverageCadenceUpdateTime.duration(to: now) > .seconds(3) {
             averageCadence.update(value: 0)
         }
-        return averageCadence.averageIgnoreZeros()
+    }
+
+    private func updateSpeed(measurement: CscMeasurement, now: ContinuousClock.Instant) {
+        var speed = -1.0
+        if let revolutions = measurement.cumulativeWheelRevolutions,
+           let time = measurement.lastWheelEventTime
+        {
+            if let previousWheelRevolutions, let previousWheelRevolutionsTime {
+                var deltaRevolutions = Int(revolutions) - Int(previousWheelRevolutions)
+                if deltaRevolutions < 0 {
+                    deltaRevolutions += 4_294_967_296
+                }
+                var deltaTime = Int(time) - Int(previousWheelRevolutionsTime)
+                if deltaTime < 0 {
+                    deltaTime += 65536
+                }
+                let deltaTimeSeconds = Double(deltaTime) / 1024
+                if deltaTimeSeconds > 0 {
+                    speed = Double(deltaRevolutions) * wheelCircumferenceMeters / deltaTimeSeconds
+                    speed = min(speed, 100)
+                }
+            }
+            previousWheelRevolutions = revolutions
+            previousWheelRevolutionsTime = time
+        }
+        if speed != -1.0 {
+            averageSpeed.update(value: speed)
+            latestAverageSpeedUpdateTime = now
+        } else if latestAverageSpeedUpdateTime.duration(to: now) > .seconds(3) {
+            averageSpeed.update(value: 0)
+        }
     }
 }

--- a/Moblin/Integrations/WorkoutDevice/WorkoutDeviceCyclingSpeedCadence.swift
+++ b/Moblin/Integrations/WorkoutDevice/WorkoutDeviceCyclingSpeedCadence.swift
@@ -1,0 +1,107 @@
+@preconcurrency import CoreBluetooth
+import Foundation
+
+let workoutDeviceCyclingSpeedCadenceServiceId = CBUUID(string: "1816")
+let workoutDeviceCscMeasurementCharacteristicId = CBUUID(string: "2A5B")
+
+private let measurementWheelRevolutionDataFlagIndex = 0
+private let measurementCrankRevolutionDataFlagIndex = 1
+
+private let averageSampleCount = 3
+
+private struct CscMeasurement {
+    // periphery:ignore
+    var cumulativeWheelRevolutions: UInt32?
+    // periphery:ignore
+    var lastWheelEventTime: UInt16?
+    var cumulativeCrankRevolutions: UInt16?
+    var lastCrankEventTime: UInt16?
+
+    init(value: Data) throws {
+        let reader = ByteReader(data: value)
+        let flags = try reader.readUInt8()
+        if flags.isBitSet(index: measurementWheelRevolutionDataFlagIndex) {
+            cumulativeWheelRevolutions = try reader.readUInt32Le()
+            lastWheelEventTime = try reader.readUInt16Le()
+        }
+        if flags.isBitSet(index: measurementCrankRevolutionDataFlagIndex) {
+            cumulativeCrankRevolutions = try reader.readUInt16Le()
+            lastCrankEventTime = try reader.readUInt16Le()
+        }
+    }
+}
+
+private class AverageCadenceCalculator {
+    private var values = Array(repeating: 0, count: averageSampleCount)
+    private var nextIndex = 0
+
+    func update(value: Int) {
+        values[nextIndex] = value
+        nextIndex += 1
+        nextIndex %= averageSampleCount
+    }
+
+    func averageIgnoreZeros() -> Int {
+        let numberOfNonZeroValues = values.filter { $0 != 0 }.count
+        guard numberOfNonZeroValues > 0 else {
+            return 0
+        }
+        return values.reduce(0, +) / numberOfNonZeroValues
+    }
+}
+
+class WorkoutDeviceCyclingSpeedCadence {
+    private var measurementCharacteristic: CBCharacteristic?
+    private var previousCrankRevolutions: UInt16?
+    private var previousCrankRevolutionsTime: UInt16?
+    private var averageCadence = AverageCadenceCalculator()
+    private var latestAverageCadenceUpdateTime = ContinuousClock.now
+
+    func reset() {
+        measurementCharacteristic = nil
+        previousCrankRevolutions = nil
+        previousCrankRevolutionsTime = nil
+    }
+
+    func setMeasurementCharacteristic(_ characteristic: CBCharacteristic) {
+        measurementCharacteristic = characteristic
+    }
+
+    func isAnyCharacteristicDiscovered() -> Bool {
+        measurementCharacteristic != nil
+    }
+
+    func handleMeasurement(value: Data) throws -> Int {
+        let measurement = try CscMeasurement(value: value)
+        var cadence = -1.0
+        if let revolutions = measurement.cumulativeCrankRevolutions,
+           let time = measurement.lastCrankEventTime
+        {
+            if let previousCrankRevolutions, let previousCrankRevolutionsTime {
+                var deltaRevolutions = Int(revolutions) - Int(previousCrankRevolutions)
+                if deltaRevolutions < 0 {
+                    deltaRevolutions += 65536
+                }
+                var deltaTime = Int(time) - Int(previousCrankRevolutionsTime)
+                if deltaTime < 0 {
+                    deltaTime += 65536
+                }
+                let deltaTimeSeconds = Double(deltaTime) / 1024
+                if deltaTimeSeconds > 0 {
+                    cadence = 60 * Double(deltaRevolutions) / deltaTimeSeconds
+                    cadence = min(cadence, 10000)
+                }
+            }
+            previousCrankRevolutions = revolutions
+            previousCrankRevolutionsTime = time
+        }
+        let now = ContinuousClock.now
+        if cadence != -1.0 {
+            averageCadence.update(value: Int(cadence))
+            latestAverageCadenceUpdateTime = now
+        } else if latestAverageCadenceUpdateTime.duration(to: now) > .seconds(3) {
+            averageCadence.update(value: 0)
+        }
+        return averageCadence.averageIgnoreZeros()
+    }
+}

--- a/Moblin/RemoteControl/RemoteControl.swift
+++ b/Moblin/RemoteControl/RemoteControl.swift
@@ -587,6 +587,7 @@ struct RemoteControlRemoteSceneDataTextStats: Codable {
     let teslaMedia: String
     let cyclingPower: String
     let cyclingCadence: String
+    let cyclingSpeed: Double
     let runningMetrics: [String: WorkoutDeviceRunningMetrics]
     let browserTitle: String
     let gForce: GForce?
@@ -632,6 +633,7 @@ struct RemoteControlRemoteSceneDataTextStats: Codable {
         teslaMedia = stats.teslaMedia
         cyclingPower = stats.cyclingPower
         cyclingCadence = stats.cyclingCadence
+        cyclingSpeed = stats.cyclingSpeed
         runningMetrics = stats.runningMetrics
         browserTitle = stats.browserTitle
         gForce = stats.gForce
@@ -679,6 +681,7 @@ struct RemoteControlRemoteSceneDataTextStats: Codable {
                         teslaMedia: teslaMedia,
                         cyclingPower: cyclingPower,
                         cyclingCadence: cyclingCadence,
+                        cyclingSpeed: cyclingSpeed,
                         runningMetrics: runningMetrics,
                         browserTitle: browserTitle,
                         gForce: gForce,

--- a/Moblin/Various/Model/Model.swift
+++ b/Moblin/Various/Model/Model.swift
@@ -615,6 +615,7 @@ final class Model: NSObject, ObservableObject, @unchecked Sendable {
     var catPrinters: [UUID: CatPrinter] = [:]
     var cyclingPower = 0
     var cyclingCadence = 0
+    var cyclingSpeed = 0.0
     var latestSubscriber = ""
     var latestFollower = ""
     private let periodicTimer20ms = SimpleTimer(queue: .main)

--- a/Moblin/Various/Model/ModelScene.swift
+++ b/Moblin/Various/Model/ModelScene.swift
@@ -1567,6 +1567,7 @@ extension Model {
                 teslaMedia: textEffectTeslaMedia(),
                 cyclingPower: "\(cyclingPower) W",
                 cyclingCadence: "\(cyclingCadence)",
+                cyclingSpeed: cyclingSpeed,
                 runningMetrics: runningMetrics,
                 browserTitle: getBrowserTitle(),
                 gForce: gForceManager?.getLatest(),

--- a/Moblin/Various/Model/ModelWorkoutDevice.swift
+++ b/Moblin/Various/Model/ModelWorkoutDevice.swift
@@ -85,8 +85,9 @@ extension Model: @preconcurrency WorkoutDeviceDelegate {
         }
     }
 
-    func workoutDeviceCyclingSpeedCadence(_: WorkoutDevice, cadence: Int) {
+    func workoutDeviceCyclingSpeedCadence(_: WorkoutDevice, speed: Double, cadence: Int) {
         DispatchQueue.main.async {
+            self.cyclingSpeed = speed
             self.cyclingCadence = cadence
         }
     }

--- a/Moblin/Various/Model/ModelWorkoutDevice.swift
+++ b/Moblin/Various/Model/ModelWorkoutDevice.swift
@@ -85,6 +85,12 @@ extension Model: @preconcurrency WorkoutDeviceDelegate {
         }
     }
 
+    func workoutDeviceCyclingSpeedCadence(_: WorkoutDevice, cadence: Int) {
+        DispatchQueue.main.async {
+            self.cyclingCadence = cadence
+        }
+    }
+
     func workoutDeviceRunningMetrics(_ device: WorkoutDevice, metrics: WorkoutDeviceRunningMetrics) {
         DispatchQueue.main.async {
             guard let device = self.getWorkoutDeviceSettings(device: device) else {

--- a/Moblin/VideoEffects/Text/TextEffect.swift
+++ b/Moblin/VideoEffects/Text/TextEffect.swift
@@ -43,6 +43,7 @@ struct TextEffectStats {
     let teslaMedia: String
     let cyclingPower: String
     let cyclingCadence: String
+    let cyclingSpeed: Double
     let runningMetrics: [String: WorkoutDeviceRunningMetrics]
     let browserTitle: String
     let gForce: GForce?

--- a/Moblin/VideoEffects/Text/TextEffectFormatter.swift
+++ b/Moblin/VideoEffects/Text/TextEffectFormatter.swift
@@ -183,6 +183,8 @@ class TextEffectFormatter {
                 formatCyclingPower(stats: stats)
             case .cyclingCadence:
                 formatCyclingCadence(stats: stats)
+            case let .cyclingSpeed(unit):
+                formatCyclingSpeed(stats: stats, unit: unit)
             case let .runningPace(deviceName):
                 formatRunningPace(stats: stats, deviceName: deviceName)
             case let .runningCadence(deviceName):
@@ -483,6 +485,10 @@ class TextEffectFormatter {
 
     private func formatCyclingCadence(stats: TextEffectStats) {
         appendTextPart(value: stats.cyclingCadence)
+    }
+
+    private func formatCyclingSpeed(stats: TextEffectStats, unit: TextFormatSpeedUnit) {
+        appendTextPart(value: formatSpeed(speed: stats.cyclingSpeed, unit: unit))
     }
 
     private func formatRunningPace(stats: TextEffectStats, deviceName: String) {

--- a/Moblin/VideoEffects/Text/TextFormatStringLoader.swift
+++ b/Moblin/VideoEffects/Text/TextFormatStringLoader.swift
@@ -270,6 +270,7 @@ enum TextFormatPart: Equatable {
     case teslaMedia
     case cyclingPower
     case cyclingCadence
+    case cyclingSpeed(TextFormatSpeedUnit)
     case runningPace(String)
     case runningCadence(String)
     case runningDistance(String)
@@ -377,6 +378,7 @@ class TextFormatLoader {
                     loadItem(part: .cyclingPower, offsetBy: 14)
                 } else if formatFromIndex.hasPrefix("{cyclingcadence}") {
                     loadItem(part: .cyclingCadence, offsetBy: 16)
+                } else if appendCyclingSpeedIfPresent(formatFromIndex: formatFromIndex) {
                 } else if formatFromIndex.hasPrefix("{laptimes}") {
                     loadItem(part: .lapTimes, offsetBy: 10)
                 } else if formatFromIndex.hasPrefix("{browsertitle}") {
@@ -409,6 +411,13 @@ class TextFormatLoader {
                                "{speed}",
                                /{speed:([^}]+)}/,
                                TextFormatSpeedUnit.init) { .speed($0 ?? .system) }
+    }
+
+    private func appendCyclingSpeedIfPresent(formatFromIndex: String) -> Bool {
+        appendOptionsIfPresent(formatFromIndex,
+                               "{cyclingspeed}",
+                               /{cyclingspeed:([^}]+)}/,
+                               TextFormatSpeedUnit.init) { .cyclingSpeed($0 ?? .system) }
     }
 
     private func appendAverageSpeedIfPresent(formatFromIndex: String) -> Bool {

--- a/Moblin/View/Settings/About/AboutVersionHistorySettingsView.swift
+++ b/Moblin/View/Settings/About/AboutVersionHistorySettingsView.swift
@@ -10,7 +10,7 @@ struct Version {
 private let versions = [
     Version(version: "33.12.0", date: "2026-07-23", changes: [
         "• Support for cycling speed and cadence (CSC) sensors.",
-        "  • Shows up as workout devices. Use {cyclingCadence} in text widget.",
+        "  • Shows up as workout devices. Use {cyclingCadence} and {cyclingSpeed} in text widget.",
         "• Try to make chat usernames more readable on dark background. 💡 Tican",
         "• Set talkback mic in remote control. Streamer side only.",
         "• Make SRT client ingest work when reconnecting. 🐛 iesv",

--- a/Moblin/View/Settings/About/AboutVersionHistorySettingsView.swift
+++ b/Moblin/View/Settings/About/AboutVersionHistorySettingsView.swift
@@ -9,6 +9,8 @@ struct Version {
 // swiftlint:disable line_length
 private let versions = [
     Version(version: "33.12.0", date: "2026-07-23", changes: [
+        "• Support for cycling speed and cadence (CSC) sensors.",
+        "  • Shows up as workout devices. Use {cyclingCadence} in text widget.",
         "• Try to make chat usernames more readable on dark background. 💡 Tican",
         "• Set talkback mic in remote control. Streamer side only.",
         "• Make SRT client ingest work when reconnecting. 🐛 iesv",

--- a/Moblin/View/Settings/Scenes/Widgets/Widget/Text/WidgetTextSettingsView.swift
+++ b/Moblin/View/Settings/Scenes/Widgets/Widget/Text/WidgetTextSettingsView.swift
@@ -1083,6 +1083,16 @@ private struct WorkoutVariablesView: View {
                         description: String(localized: "Show cycling cadence"),
                         text: $value
                     )
+                    VariableView(
+                        title: "{cyclingSpeed}",
+                        description: String(localized: "Show cycling speed from CSC sensor"),
+                        text: $value
+                    )
+                    VariableView(
+                        title: "{cyclingSpeed:km/h}",
+                        description: String(localized: "Show cycling speed in km/h"),
+                        text: $value
+                    )
                 }
             }
             .navigationTitle("Workout")

--- a/MoblinTests/TextEffectSuite.swift
+++ b/MoblinTests/TextEffectSuite.swift
@@ -346,6 +346,7 @@ struct TextEffectSuite {
                         teslaMedia: "",
                         cyclingPower: "",
                         cyclingCadence: "",
+                        cyclingSpeed: 0,
                         runningMetrics: [:],
                         browserTitle: "",
                         gForce: gForce,

--- a/MoblinTests/WorkoutDeviceCyclingSpeedCadenceSuite.swift
+++ b/MoblinTests/WorkoutDeviceCyclingSpeedCadenceSuite.swift
@@ -1,0 +1,58 @@
+import CoreBluetooth
+import Foundation
+@testable import Moblin
+import Testing
+
+struct WorkoutDeviceCyclingSpeedCadenceSuite {
+    private func crankOnlyMeasurement(revolutions: UInt16, eventTime: UInt16) -> Data {
+        var data = Data([0x02])
+        data.append(contentsOf: withUnsafeBytes(of: revolutions.littleEndian, Array.init))
+        data.append(contentsOf: withUnsafeBytes(of: eventTime.littleEndian, Array.init))
+        return data
+    }
+
+    private func wheelOnlyMeasurement(revolutions: UInt32, eventTime: UInt16) -> Data {
+        var data = Data([0x01])
+        data.append(contentsOf: withUnsafeBytes(of: revolutions.littleEndian, Array.init))
+        data.append(contentsOf: withUnsafeBytes(of: eventTime.littleEndian, Array.init))
+        return data
+    }
+
+    @Test
+    func firstCrankMeasurementReturnsZeroCadence() throws {
+        let device = WorkoutDeviceCyclingSpeedCadence()
+        let cadence = try device.handleMeasurement(value: crankOnlyMeasurement(revolutions: 100, eventTime: 0))
+        #expect(cadence == 0)
+    }
+
+    @Test
+    func crankCadenceIsSixtyRpmWhenOneRevolutionPerSecond() throws {
+        let device = WorkoutDeviceCyclingSpeedCadence()
+        _ = try device.handleMeasurement(value: crankOnlyMeasurement(revolutions: 100, eventTime: 0))
+        let cadence = try device.handleMeasurement(value: crankOnlyMeasurement(revolutions: 101, eventTime: 1024))
+        #expect(cadence == 60)
+    }
+
+    @Test
+    func crankEventTimeRolloverIsHandled() throws {
+        let device = WorkoutDeviceCyclingSpeedCadence()
+        _ = try device.handleMeasurement(value: crankOnlyMeasurement(revolutions: 10, eventTime: 65500))
+        // 136 ticks later after rollover ≈ 0.1328 s for 1 rev → ~452 RPM, then averaged
+        let cadence = try device.handleMeasurement(value: crankOnlyMeasurement(revolutions: 11, eventTime: 100))
+        #expect(cadence > 0)
+    }
+
+    @Test
+    func wheelOnlyMeasurementDoesNotProduceCadence() throws {
+        let device = WorkoutDeviceCyclingSpeedCadence()
+        _ = try device.handleMeasurement(value: wheelOnlyMeasurement(revolutions: 1000, eventTime: 0))
+        let cadence = try device.handleMeasurement(value: wheelOnlyMeasurement(revolutions: 1010, eventTime: 1024))
+        #expect(cadence == 0)
+    }
+
+    @Test
+    func serviceAndCharacteristicUuidsMatchBluetoothSpec() {
+        #expect(workoutDeviceCyclingSpeedCadenceServiceId == CBUUID(string: "1816"))
+        #expect(workoutDeviceCscMeasurementCharacteristicId == CBUUID(string: "2A5B"))
+    }
+}

--- a/MoblinTests/WorkoutDeviceCyclingSpeedCadenceSuite.swift
+++ b/MoblinTests/WorkoutDeviceCyclingSpeedCadenceSuite.swift
@@ -21,33 +21,43 @@ struct WorkoutDeviceCyclingSpeedCadenceSuite {
     @Test
     func firstCrankMeasurementReturnsZeroCadence() throws {
         let device = WorkoutDeviceCyclingSpeedCadence()
-        let cadence = try device.handleMeasurement(value: crankOnlyMeasurement(revolutions: 100, eventTime: 0))
-        #expect(cadence == 0)
+        let result = try device.handleMeasurement(value: crankOnlyMeasurement(revolutions: 100, eventTime: 0))
+        #expect(result.cadence == 0)
+        #expect(result.speedMetersPerSecond == 0)
     }
 
     @Test
     func crankCadenceIsSixtyRpmWhenOneRevolutionPerSecond() throws {
         let device = WorkoutDeviceCyclingSpeedCadence()
         _ = try device.handleMeasurement(value: crankOnlyMeasurement(revolutions: 100, eventTime: 0))
-        let cadence = try device.handleMeasurement(value: crankOnlyMeasurement(revolutions: 101, eventTime: 1024))
-        #expect(cadence == 60)
+        let result = try device.handleMeasurement(value: crankOnlyMeasurement(revolutions: 101, eventTime: 1024))
+        #expect(result.cadence == 60)
     }
 
     @Test
     func crankEventTimeRolloverIsHandled() throws {
         let device = WorkoutDeviceCyclingSpeedCadence()
         _ = try device.handleMeasurement(value: crankOnlyMeasurement(revolutions: 10, eventTime: 65500))
-        // 136 ticks later after rollover ≈ 0.1328 s for 1 rev → ~452 RPM, then averaged
-        let cadence = try device.handleMeasurement(value: crankOnlyMeasurement(revolutions: 11, eventTime: 100))
-        #expect(cadence > 0)
+        let result = try device.handleMeasurement(value: crankOnlyMeasurement(revolutions: 11, eventTime: 100))
+        #expect(result.cadence > 0)
     }
 
     @Test
     func wheelOnlyMeasurementDoesNotProduceCadence() throws {
         let device = WorkoutDeviceCyclingSpeedCadence()
         _ = try device.handleMeasurement(value: wheelOnlyMeasurement(revolutions: 1000, eventTime: 0))
-        let cadence = try device.handleMeasurement(value: wheelOnlyMeasurement(revolutions: 1010, eventTime: 1024))
-        #expect(cadence == 0)
+        let result = try device.handleMeasurement(value: wheelOnlyMeasurement(revolutions: 1010, eventTime: 1024))
+        #expect(result.cadence == 0)
+    }
+
+    @Test
+    func wheelSpeedUsesDefaultCircumference() throws {
+        let device = WorkoutDeviceCyclingSpeedCadence()
+        _ = try device.handleMeasurement(value: wheelOnlyMeasurement(revolutions: 100, eventTime: 0))
+        // 1 wheel rev in 1 second → circumference m/s
+        let result = try device.handleMeasurement(value: wheelOnlyMeasurement(revolutions: 101, eventTime: 1024))
+        #expect(abs(result.speedMetersPerSecond - workoutDeviceDefaultWheelCircumferenceMeters) < 0.001)
+        #expect(result.cadence == 0)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Add Bluetooth LE Cycling Speed and Cadence (CSC) service `0x1816` support so sensors like Cycplus appear in Workout devices.
- Feed cadence into the existing `{cyclingCadence}` text widget variable (same path as cycling power meters).
- Include unit tests for CSC measurement / cadence calculation.

## Test plan
- [ ] Build Moblin and open Settings → Workout devices
- [ ] Pair a CSC cadence (or speed+cadence) sensor such as Cycplus
- [ ] Confirm device reaches Connected
- [ ] Add `{cyclingCadence}` to a text widget and verify cadence updates while pedaling
- [ ] Confirm existing heart rate / cycling power devices still work


Made with [Cursor](https://cursor.com)